### PR TITLE
Save role identity selection in local storage

### DIFF
--- a/frontend/src/features/identity/IdentityContext.tsx
+++ b/frontend/src/features/identity/IdentityContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, use, useMemo, useState } from 'react';
+import React, { createContext, use, useCallback, useMemo, useState } from 'react';
 import { TAIdentity } from '../../api/dashboard/types';
 
 export interface Identity {
@@ -12,17 +12,31 @@ interface IdentityContextType {
   identity?: Identity;
   detailedIdentity?: TAIdentity;
   setIdentity: React.Dispatch<React.SetStateAction<Identity | undefined>>;
-  setDetailedIdentity: React.Dispatch<React.SetStateAction<TAIdentity | undefined>>;
+  setDetailedIdentity: (value?: TAIdentity) => void;
 }
 
 const IdentityContext = createContext<IdentityContextType | undefined>(undefined);
 
 export const IdentityProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const localStorageIdentityKey = 'selectedIdentity';
   const [identity, setIdentity] = useState<Identity>();
-  const [detailedIdentity, setDetailedIdentity] = useState<TAIdentity>();
+  const [detailedIdentity, setDetailedIdentity] = useState<TAIdentity | undefined>(() => {
+    const stored = localStorage.getItem(localStorageIdentityKey);
+    return stored ? JSON.parse(stored) : undefined;
+  });
+
+  const handleSetDetailedIdentity = useCallback((value?: TAIdentity) => {
+    localStorage.setItem(localStorageIdentityKey, JSON.stringify(value));
+    setDetailedIdentity(value);
+  }, []);
 
   const value = useMemo(() => {
-    return { identity, detailedIdentity, setIdentity, setDetailedIdentity };
+    return {
+      identity,
+      detailedIdentity,
+      setIdentity,
+      setDetailedIdentity: handleSetDetailedIdentity,
+    };
   }, [identity, detailedIdentity]);
 
   return <IdentityContext value={value}>{children}</IdentityContext>;


### PR DESCRIPTION
Resolves #54 

Adds logic to store and restore the user's selected identity in local storage in the browser. This way, a user's selected role will persist across sessions.