### PR TITLE
Improve experts table and workflow

### DIFF
--- a/backend/api/core/models/request_status.py
+++ b/backend/api/core/models/request_status.py
@@ -24,7 +24,7 @@ class RequestStatus(models.Model):
         """
         status, _ = cls.objects.get_or_create(
             name=cls.default_name,
-            description=cls.default_description
+            defaults={"description": cls.default_description}
         )
 
         return status.pk

--- a/backend/api/core/serializers/request.py
+++ b/backend/api/core/serializers/request.py
@@ -26,6 +26,7 @@ class RequestDetailSerializer(serializers.Serializer):
     proj_completion_date = serializers.DateField()
     actual_completion_date = serializers.DateField()
     customers = CustomerSerializer(many=True)
+    topics = TopicSerializer(many=True)
 
 class RequestListSerializer(serializers.Serializer):
     id = serializers.IntegerField()

--- a/backend/api/core/views/expert.py
+++ b/backend/api/core/views/expert.py
@@ -43,14 +43,17 @@ class ExpertsListView(views.APIView):
 
         # A(2/2): ...this loop can fail gracefully
         for assignment in expert_assignments:
+            expert_user = assignment.user
+            expert_serializer = ExpertSerializer(expert_user)
             data = dict()
-            data["id"] = assignment.user.pk
-            data["name"] = assignment.user.name
-            data["email"] = assignment.user.email
+            data["id"] = expert_user.pk
+            data["owner_id"] = expert_serializer.data.get("owner_id")
+            data["name"] = expert_user.name
+            data["email"] = expert_user.email
             data["lab"] = LabSerializer(assignment.instance).data
 
             expertise_list = list()
-            expertise_entries = Expertise.objects.filter(user=assignment.user.pk)
+            expertise_entries = Expertise.objects.filter(user=expert_user.pk)
             for expertise_entry in expertise_entries:
                 expertise = dict()
                 maybe_topic = None
@@ -70,7 +73,7 @@ class ExpertsListView(views.APIView):
 
             data["expertises"] = expertise_list
 
-            expert_user = assignment.user
+            # expert_user = assignment.user
             expert_requests = Request.objects.filter(expert=expert_user)
             active_requests = expert_requests.exclude(owner=None)
             data["active_requests_count"] = active_requests.count()

--- a/backend/api/core/views/expert.py
+++ b/backend/api/core/views/expert.py
@@ -7,7 +7,7 @@ from core.views.request import BaseUserAwareRequest
 from core.models import *
 from core.serializers import *
 from core.permissions import *
-from core.constants import ROLE
+from core.constants import ROLE, REQUEST_STATUS
 
 from allauth.headless.contrib.rest_framework.authentication import (
     XSessionTokenAuthentication,
@@ -70,8 +70,11 @@ class ExpertsListView(views.APIView):
 
             data["expertises"] = expertise_list
 
-            request_data = RequestExpertListSerializer(Request.objects.filter(expert=User.objects.get(pk=self.request.user.id)), many=True).data
-            data["requests"] = request_data
+            expert_user = assignment.user
+            expert_requests = Request.objects.filter(expert=expert_user)
+            active_requests = expert_requests.exclude(owner=None)
+            data["active_requests_count"] = active_requests.count()
+            data["total_requests_count"] = expert_requests.count()
 
             experts_data.append(data)
         

--- a/backend/api/core/views/expert.py
+++ b/backend/api/core/views/expert.py
@@ -28,6 +28,16 @@ class ExpertsListView(views.APIView):
         expert_assignments = list()
         if IsAdmin().has_permission(request):
             expert_assignments = LabRoleAssignment.objects.filter(role=Role.objects.get(name=ROLE.EXPERT))
+        elif IsProgramLead().has_permission(request):
+            maybe_context = self.request.headers.get("Context")
+            if not maybe_context:
+                return Response(data={"message": "Please include identity context with request"}, status=status.HTTP_400_BAD_REQUEST)
+
+            context = json.loads(maybe_context) 
+            try:
+                expert_assignments = LabRoleAssignment.objects.filter(role=Role.objects.get(name=ROLE.EXPERT), program=Program.objects.get(pk=context.get("instance")))
+            except Exception as e:
+                return Response(data={"message": f"{e}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         elif IsLabLead().has_permission(request):
             maybe_context = self.request.headers.get("Context")
             if not maybe_context:

--- a/frontend/src/api/dashboard/types.ts
+++ b/frontend/src/api/dashboard/types.ts
@@ -89,7 +89,7 @@ export interface TAExpert {
   owner_id: number;
   email: string;
   name: string;
-  expertise: TAExpertise[];
+  expertises: TAExpertise[];
   lab?: TALab;
   active_requests_count?: number;
   total_requests_count?: number;

--- a/frontend/src/api/dashboard/types.ts
+++ b/frontend/src/api/dashboard/types.ts
@@ -90,6 +90,9 @@ export interface TAExpert {
   email: string;
   name: string;
   expertise: TAExpertise[];
+  lab?: TALab;
+  active_requests_count?: number;
+  total_requests_count?: number;
 }
 
 export interface TAProgram {

--- a/frontend/src/components/CellWithPopover.tsx
+++ b/frontend/src/components/CellWithPopover.tsx
@@ -1,0 +1,66 @@
+import { Box, Popover } from '@mui/material';
+import { PropsWithChildren, useState } from 'react';
+
+/**
+ * Generic inner cell content with a popover to show the full contents.
+ * This is used to render cells with too much content to display
+ * inside a single cell. Full content is displayed on hover in a popover box.
+ */
+export const CellWithPopover: React.FC<PropsWithChildren> = ({ children }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  return (
+    <Box onMouseLeave={handlePopoverClose} sx={{ height: '100%' }}>
+      <Box
+        onMouseEnter={handlePopoverOpen}
+        onMouseLeave={handlePopoverClose}
+        sx={{
+          height: '100%',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {children}
+      </Box>
+      <Popover
+        id="mouse-over-popover"
+        sx={{
+          pointerEvents: 'none',
+        }}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        onClose={handlePopoverClose}
+        disableRestoreFocus
+      >
+        <Box
+          onMouseEnter={handlePopoverOpen}
+          onMouseLeave={handlePopoverClose}
+          sx={{
+            maxWidth: '300px',
+            padding: 2,
+            pointerEvents: 'auto',
+          }}
+        >
+          {children}
+        </Box>
+      </Popover>
+    </Box>
+  );
+};

--- a/frontend/src/declarations.ts
+++ b/frontend/src/declarations.ts
@@ -2,6 +2,6 @@ import { TAExpert } from './api/dashboard/types';
 
 declare module '@mui/x-data-grid' {
   interface ToolbarPropsOverrides {
-    experts: TAExpert[];
+    experts: TAExpert[] | null;
   }
 }

--- a/frontend/src/features/experts/ExpertsDataHeader.tsx
+++ b/frontend/src/features/experts/ExpertsDataHeader.tsx
@@ -2,10 +2,13 @@ import { Typography } from '@mui/material';
 import { TAExpert } from '../../api/dashboard/types';
 
 interface ExpertsDataHeaderProps {
-  experts: TAExpert[];
+  experts: TAExpert[] | null;
 }
 
 export const ExpertsDataHeader: React.FC<ExpertsDataHeaderProps> = ({ experts }) => {
+  if (experts === null) {
+    return <Typography sx={{ flex: 1, mx: 0.5 }}>Loading...</Typography>;
+  }
   return (
     <Typography sx={{ flex: 1, mx: 0.5 }}>
       {experts.length} {experts.length === 1 ? 'expert' : 'experts'}

--- a/frontend/src/features/experts/ExpertsDataTable.tsx
+++ b/frontend/src/features/experts/ExpertsDataTable.tsx
@@ -1,26 +1,15 @@
 import { CellWithPopover } from '@/components/CellWithPopover';
-import { Button, Chip, Paper, Stack, Tooltip } from '@mui/material';
+import { Chip, Paper, Stack, Tooltip } from '@mui/material';
 import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import CircularProgress from '@mui/material/CircularProgress';
-import ErrorIcon from '@mui/icons-material/Error';
-import { useNavigate } from '@tanstack/react-router';
-import { TAExpert, TAExpertise, TAOwner } from '../../api/dashboard/types';
+import { TAExpert, TAExpertise } from '../../api/dashboard/types';
 import { ExpertsToolbar } from './ExpertsToolbar';
-import { queryClient } from '@/App';
-import { useIdentityContext } from '@/features/identity/IdentityContext';
-import { useRequestsContext } from '@/features/requests/RequestsContext';
-import { useToastContext } from '@/features/toasts/ToastContext';
-import { ToastMessage } from '@/features/toasts/ToastMessage';
-import { useAssignmentMutation } from '@/utils/queryOptions';
 
 interface ExpertsDataTableProps {
   experts: TAExpert[] | null;
-  showAssignColumn?: boolean;
-  currentRequestId?: number;
+  columns?: GridColDef[];
 }
 
-const columns: GridColDef[] = [
+export const expertColumns: GridColDef[] = [
   { field: 'name', headerName: 'Name', width: 150 },
   { field: 'email', headerName: 'Email', width: 150 },
   {
@@ -70,89 +59,20 @@ const columns: GridColDef[] = [
   },
 ];
 
+/**
+ * Data table component for displaying experts.
+ * Used in the Experts page and also in the request details page (as ExpertsPanelDataTable).
+ */
 export const ExpertsDataTable: React.FC<ExpertsDataTableProps> = ({
   experts,
-  showAssignColumn,
-  currentRequestId,
+  columns = expertColumns,
 }) => {
-  const navigate = useNavigate();
-  const { identity } = useIdentityContext();
-  const { tab, nextId, previousId, setExpertsPanelOpen } = useRequestsContext();
-  const { setShowToast, setToastMessage } = useToastContext();
-  const onMutate = (message: string) => {
-    return () => {
-      setShowToast(true);
-      setToastMessage(
-        <ToastMessage>
-          <Stack direction="row" alignItems="center">
-            <CircularProgress size="1.25rem" color="info" />
-            <span>{message}</span>
-          </Stack>
-        </ToastMessage>
-      );
-    };
-  };
-  const onSuccess = (message: string) => {
-    return () => {
-      queryClient.invalidateQueries();
-      setShowToast(true);
-      setToastMessage(<ToastMessage icon={<CheckCircleIcon />}>{message}</ToastMessage>);
-      if (nextId) {
-        navigate({
-          to: `/requests/${tab}/${nextId}`,
-          params: { requestId: nextId.toString() },
-        });
-      } else if (previousId) {
-        navigate({
-          to: `/requests/${tab}/${previousId}`,
-          params: { requestId: previousId.toString() },
-        });
-      }
-    };
-  };
-  const onError = (error: Error) => {
-    setShowToast(true);
-    setToastMessage(<ToastMessage icon={<ErrorIcon />}>{error.message}</ToastMessage>);
-  };
-  const assignRequestMutation = currentRequestId
-    ? useAssignmentMutation(currentRequestId.toString(), identity, {
-        onMutate: onMutate('Assigning request'),
-        onSuccess: onSuccess('Request assigned'),
-        onError: onError,
-      })
-    : null;
-
-  const handleAssignment = (expert: TAExpert) => {
-    if (!assignRequestMutation || !currentRequestId) return;
-    assignRequestMutation.mutate({ request: currentRequestId, owner: expert.owner_id });
-    setExpertsPanelOpen(false);
-  };
-
-  const assignColumn: GridColDef = {
-    field: 'assign',
-    headerName: 'Assign',
-    width: 150,
-    type: 'custom',
-    align: 'center',
-    headerAlign: 'center',
-    renderCell: (params) => (
-      <Button
-        variant="contained"
-        color="primary"
-        size="small"
-        onClick={() => handleAssignment(params.row)}
-      >
-        Assign
-      </Button>
-    ),
-  };
-
   return (
     <Paper>
       <DataGrid
         loading={experts === null}
         rows={experts || []}
-        columns={showAssignColumn ? [...columns, assignColumn] : columns}
+        columns={columns}
         disableRowSelectionOnClick
         showToolbar
         slots={{ toolbar: ExpertsToolbar }}

--- a/frontend/src/features/experts/ExpertsDataTable.tsx
+++ b/frontend/src/features/experts/ExpertsDataTable.tsx
@@ -2,14 +2,15 @@ import { Chip, Paper, Stack, Tooltip } from '@mui/material';
 import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { TAExpert, TAExpertise } from '../../api/dashboard/types';
 import { ExpertsToolbar } from './ExpertsToolbar';
+import { CellWithPopover } from '@/components/CellWithPopover';
 
 interface ExpertsDataTableProps {
-  experts: TAExpert[];
+  experts: TAExpert[] | null;
 }
 
 const columns: GridColDef[] = [
-  { field: 'name', headerName: 'Name', width: 200 },
-  { field: 'email', headerName: 'Email', width: 200 },
+  { field: 'name', headerName: 'Name', width: 150 },
+  { field: 'email', headerName: 'Email', width: 150 },
   {
     field: 'lab',
     headerName: 'Lab',
@@ -31,26 +32,28 @@ const columns: GridColDef[] = [
     renderCell: (params: GridRenderCellParams<any, string>) => {
       const values = params.value?.split('__') || [];
       return (
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ height: '100%' }}>
-          {values.map((expertiseStr: string) => (
-            <Tooltip key={expertiseStr} title={expertiseStr.split('++')[1] || ''} placement="top">
-              <Chip label={`${expertiseStr.split('++')[0]}`} variant="outlined" />
-            </Tooltip>
-          ))}
-        </Stack>
+        <CellWithPopover>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ height: '100%' }}>
+            {values.map((expertiseStr: string) => (
+              <Tooltip key={expertiseStr} title={expertiseStr.split('++')[1] || ''} placement="top">
+                <Chip label={`${expertiseStr.split('++')[0]}`} variant="outlined" />
+              </Tooltip>
+            ))}
+          </Stack>
+        </CellWithPopover>
       );
     },
   },
   {
     field: 'active_requests_count',
     headerName: 'Active Requests',
-    width: 200,
+    width: 150,
     type: 'number',
   },
   {
     field: 'total_requests_count',
     headerName: 'Total Requests',
-    width: 200,
+    width: 150,
     type: 'number',
   },
 ];
@@ -59,6 +62,7 @@ export const ExpertsDataTable: React.FC<ExpertsDataTableProps> = ({ experts }) =
   return (
     <Paper>
       <DataGrid
+        loading={experts === null}
         rows={experts || []}
         columns={columns}
         showToolbar

--- a/frontend/src/features/experts/ExpertsDataTable.tsx
+++ b/frontend/src/features/experts/ExpertsDataTable.tsx
@@ -1,11 +1,23 @@
-import { Chip, Paper, Stack, Tooltip } from '@mui/material';
-import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-import { TAExpert, TAExpertise } from '../../api/dashboard/types';
-import { ExpertsToolbar } from './ExpertsToolbar';
 import { CellWithPopover } from '@/components/CellWithPopover';
+import { Button, Chip, Paper, Stack, Tooltip } from '@mui/material';
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CircularProgress from '@mui/material/CircularProgress';
+import ErrorIcon from '@mui/icons-material/Error';
+import { useNavigate } from '@tanstack/react-router';
+import { TAExpert, TAExpertise, TAOwner } from '../../api/dashboard/types';
+import { ExpertsToolbar } from './ExpertsToolbar';
+import { queryClient } from '@/App';
+import { useIdentityContext } from '@/features/identity/IdentityContext';
+import { useRequestsContext } from '@/features/requests/RequestsContext';
+import { useToastContext } from '@/features/toasts/ToastContext';
+import { ToastMessage } from '@/features/toasts/ToastMessage';
+import { useAssignmentMutation } from '@/utils/queryOptions';
 
 interface ExpertsDataTableProps {
   experts: TAExpert[] | null;
+  showAssignColumn?: boolean;
+  currentRequestId?: number;
 }
 
 const columns: GridColDef[] = [
@@ -58,13 +70,90 @@ const columns: GridColDef[] = [
   },
 ];
 
-export const ExpertsDataTable: React.FC<ExpertsDataTableProps> = ({ experts }) => {
+export const ExpertsDataTable: React.FC<ExpertsDataTableProps> = ({
+  experts,
+  showAssignColumn,
+  currentRequestId,
+}) => {
+  const navigate = useNavigate();
+  const { identity } = useIdentityContext();
+  const { tab, nextId, previousId, setExpertsPanelOpen } = useRequestsContext();
+  const { setShowToast, setToastMessage } = useToastContext();
+  const onMutate = (message: string) => {
+    return () => {
+      setShowToast(true);
+      setToastMessage(
+        <ToastMessage>
+          <Stack direction="row" alignItems="center">
+            <CircularProgress size="1.25rem" color="info" />
+            <span>{message}</span>
+          </Stack>
+        </ToastMessage>
+      );
+    };
+  };
+  const onSuccess = (message: string) => {
+    return () => {
+      queryClient.invalidateQueries();
+      setShowToast(true);
+      setToastMessage(<ToastMessage icon={<CheckCircleIcon />}>{message}</ToastMessage>);
+      if (nextId) {
+        navigate({
+          to: `/requests/${tab}/${nextId}`,
+          params: { requestId: nextId.toString() },
+        });
+      } else if (previousId) {
+        navigate({
+          to: `/requests/${tab}/${previousId}`,
+          params: { requestId: previousId.toString() },
+        });
+      }
+    };
+  };
+  const onError = (error: Error) => {
+    setShowToast(true);
+    setToastMessage(<ToastMessage icon={<ErrorIcon />}>{error.message}</ToastMessage>);
+  };
+  const assignRequestMutation = currentRequestId
+    ? useAssignmentMutation(currentRequestId.toString(), identity, {
+        onMutate: onMutate('Assigning request'),
+        onSuccess: onSuccess('Request assigned'),
+        onError: onError,
+      })
+    : null;
+
+  const handleAssignment = (expert: TAExpert) => {
+    if (!assignRequestMutation || !currentRequestId) return;
+    assignRequestMutation.mutate({ request: currentRequestId, owner: expert.owner_id });
+    setExpertsPanelOpen(false);
+  };
+
+  const assignColumn: GridColDef = {
+    field: 'assign',
+    headerName: 'Assign',
+    width: 150,
+    type: 'custom',
+    align: 'center',
+    headerAlign: 'center',
+    renderCell: (params) => (
+      <Button
+        variant="contained"
+        color="primary"
+        size="small"
+        onClick={() => handleAssignment(params.row)}
+      >
+        Assign
+      </Button>
+    ),
+  };
+
   return (
     <Paper>
       <DataGrid
         loading={experts === null}
         rows={experts || []}
-        columns={columns}
+        columns={showAssignColumn ? [...columns, assignColumn] : columns}
+        disableRowSelectionOnClick
         showToolbar
         slots={{ toolbar: ExpertsToolbar }}
         slotProps={{ toolbar: { experts: experts } }}

--- a/frontend/src/features/experts/ExpertsDataTable.tsx
+++ b/frontend/src/features/experts/ExpertsDataTable.tsx
@@ -42,13 +42,16 @@ const columns: GridColDef[] = [
     },
   },
   {
-    field: 'requests',
-    headerName: 'Assigned Requests',
+    field: 'active_requests_count',
+    headerName: 'Active Requests',
     width: 200,
     type: 'number',
-    valueGetter: (value: any) => {
-      return value?.length || 0;
-    },
+  },
+  {
+    field: 'total_requests_count',
+    headerName: 'Total Requests',
+    width: 200,
+    type: 'number',
   },
 ];
 

--- a/frontend/src/features/experts/ExpertsPanelDataTable.tsx
+++ b/frontend/src/features/experts/ExpertsPanelDataTable.tsx
@@ -1,0 +1,103 @@
+import { queryClient } from '@/App';
+import { expertColumns, ExpertsDataTable } from '@/features/experts/ExpertsDataTable';
+import { useIdentityContext } from '@/features/identity/IdentityContext';
+import { useRequestsContext } from '@/features/requests/RequestsContext';
+import { useToastContext } from '@/features/toasts/ToastContext';
+import { ToastMessage } from '@/features/toasts/ToastMessage';
+import { useAssignmentMutation } from '@/utils/queryOptions';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import { Button, Stack } from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
+import { GridColDef } from '@mui/x-data-grid';
+import { useNavigate } from '@tanstack/react-router';
+import { TAExpert } from '../../api/dashboard/types';
+
+interface ExpertsPanelDataTableProps {
+  experts: TAExpert[] | null;
+  currentRequestId: number;
+}
+
+/**
+ * A special instance of the ExpertsDataTable used in the request details page.
+ * This component includes the "Assign" column which allows assigning the current
+ * request to an expert directly from the table.
+ */
+export const ExpertsPanelDataTable: React.FC<ExpertsPanelDataTableProps> = ({
+  experts,
+  currentRequestId,
+}) => {
+  const navigate = useNavigate();
+  const { identity } = useIdentityContext();
+  const { tab, nextId, previousId, setExpertsPanelOpen } = useRequestsContext();
+  const { setShowToast, setToastMessage } = useToastContext();
+  const onMutate = (message: string) => {
+    return () => {
+      setShowToast(true);
+      setToastMessage(
+        <ToastMessage>
+          <Stack direction="row" alignItems="center">
+            <CircularProgress size="1.25rem" color="info" />
+            <span>{message}</span>
+          </Stack>
+        </ToastMessage>
+      );
+    };
+  };
+  const onSuccess = (message: string) => {
+    return () => {
+      queryClient.invalidateQueries();
+      setShowToast(true);
+      setToastMessage(<ToastMessage icon={<CheckCircleIcon />}>{message}</ToastMessage>);
+      if (nextId) {
+        navigate({
+          to: `/requests/${tab}/${nextId}`,
+          params: { requestId: nextId.toString() },
+        });
+      } else if (previousId) {
+        navigate({
+          to: `/requests/${tab}/${previousId}`,
+          params: { requestId: previousId.toString() },
+        });
+      }
+    };
+  };
+  const onError = (error: Error) => {
+    setShowToast(true);
+    setToastMessage(<ToastMessage icon={<ErrorIcon />}>{error.message}</ToastMessage>);
+  };
+  const assignRequestMutation = currentRequestId
+    ? useAssignmentMutation(currentRequestId.toString(), identity, {
+        onMutate: onMutate('Assigning request'),
+        onSuccess: onSuccess('Request assigned'),
+        onError: onError,
+      })
+    : null;
+
+  const handleAssignment = (expert: TAExpert) => {
+    if (!assignRequestMutation || !currentRequestId) return;
+    assignRequestMutation.mutate({ request: currentRequestId, owner: expert.owner_id });
+    setExpertsPanelOpen(false);
+  };
+
+  const assignColumn: GridColDef = {
+    field: 'assign',
+    headerName: 'Assign',
+    width: 150,
+    type: 'custom',
+    align: 'center',
+    headerAlign: 'center',
+    renderCell: (params) => (
+      <Button
+        variant="contained"
+        color="primary"
+        size="small"
+        onClick={() => handleAssignment(params.row)}
+      >
+        Assign
+      </Button>
+    ),
+  };
+
+  return <ExpertsDataTable experts={experts} columns={[...expertColumns, assignColumn]} />;
+};

--- a/frontend/src/features/experts/ExpertsPanelDataTable.tsx
+++ b/frontend/src/features/experts/ExpertsPanelDataTable.tsx
@@ -87,6 +87,9 @@ export const ExpertsPanelDataTable: React.FC<ExpertsPanelDataTableProps> = ({
     type: 'custom',
     align: 'center',
     headerAlign: 'center',
+    sortable: false,
+    filterable: false,
+    disableColumnMenu: true,
     renderCell: (params) => (
       <Button
         variant="contained"

--- a/frontend/src/features/experts/ExpertsToolbar.tsx
+++ b/frontend/src/features/experts/ExpertsToolbar.tsx
@@ -59,7 +59,7 @@ const StyledTextField = styled(TextField)<{
 }));
 
 interface ExpertsToolbarProps {
-  experts: TAExpert[];
+  experts: TAExpert[] | null;
 }
 
 export const ExpertsToolbar: React.FC<ExpertsToolbarProps> = ({ experts }) => {

--- a/frontend/src/features/requests/RequestAssignForwardButton.tsx
+++ b/frontend/src/features/requests/RequestAssignForwardButton.tsx
@@ -1,3 +1,17 @@
+import { TAOwner, TARequestDetail } from '@/api/dashboard/types';
+import { queryClient } from '@/App';
+import { useIdentityContext } from '@/features/identity/IdentityContext';
+import { useRequestsContext } from '@/features/requests/RequestsContext';
+import { useToastContext } from '@/features/toasts/ToastContext';
+import { ToastMessage } from '@/features/toasts/ToastMessage';
+import {
+  ownersQueryOptions,
+  useAssignmentMutation,
+  useFinishCloseoutMutation,
+  useMarkCompleteMutation,
+  useReopenMutation,
+} from '@/utils/queryOptions';
+import { getStep, Steps } from '@/utils/utils';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import EastIcon from '@mui/icons-material/East';
 import ErrorIcon from '@mui/icons-material/Error';
@@ -18,21 +32,6 @@ import {
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useMemo, useState } from 'react';
-import { TAOwner, TARequestDetail } from '@/api/dashboard/types';
-import { queryClient } from '@/App';
-import {
-  ownersQueryOptions,
-  useAssignmentMutation,
-  useFinishCloseoutMutation,
-  useMarkCompleteMutation,
-  useReopenMutation,
-} from '@/utils/queryOptions';
-import { useIdentityContext } from '@/features/identity/IdentityContext';
-import { useToastContext } from '@/features/toasts/ToastContext';
-import { ToastMessage } from '@/features/toasts/ToastMessage';
-import { useRequestsContext } from '@/features/requests/RequestsContext';
-import { AppLink } from '@/components/AppLink';
-import { getStep, Steps } from '@/utils/utils';
 
 interface RequestAssignForwardButtonProps {
   request: TARequestDetail;
@@ -49,7 +48,7 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
   const navigate = useNavigate();
   const { identity, detailedIdentity } = useIdentityContext();
   const { data: owners } = useSuspenseQuery(ownersQueryOptions(identity));
-  const { tab, nextId, previousId } = useRequestsContext();
+  const { tab, nextId, previousId, setExpertsPanelOpen } = useRequestsContext();
   const { setShowToast, setToastMessage } = useToastContext();
   const [searchTerm, setSearchTerm] = useState('');
   const requestOrganizationType = request.customers[0].org.type;
@@ -153,6 +152,11 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
     setSearchTerm(event.target.value);
   };
 
+  const handleOpenExpertsPanel = () => {
+    setExpertsPanelOpen(true);
+    handleAssignMenuClose();
+  };
+
   const handleForward = (owner?: TAOwner) => {
     switch (currentStep.stepIndex) {
       case Steps.Expert:
@@ -239,18 +243,16 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
           />
         </Box>
         {ownersContainsExperts && (
-          <AppLink to="/experts">
-            <MenuItem>
-              <ListItemText sx={{ color: 'secondary.main' }}>
-                <Typography variant="body2" component="div">
-                  <Stack direction="row" alignItems="center">
-                    <span>Explore experts</span>
-                    <EastIcon />
-                  </Stack>
-                </Typography>
-              </ListItemText>
-            </MenuItem>
-          </AppLink>
+          <MenuItem onClick={handleOpenExpertsPanel}>
+            <ListItemText sx={{ color: 'secondary.main' }}>
+              <Typography variant="body2" component="div">
+                <Stack direction="row" alignItems="center">
+                  <span>Explore experts</span>
+                  <EastIcon />
+                </Stack>
+              </Typography>
+            </ListItemText>
+          </MenuItem>
         )}
         {filteredOwners?.map((owner) => (
           <MenuItem key={owner.id} onClick={() => handleForward(owner)}>

--- a/frontend/src/features/requests/RequestAssignForwardButton.tsx
+++ b/frontend/src/features/requests/RequestAssignForwardButton.tsx
@@ -5,6 +5,7 @@ import { useRequestsContext } from '@/features/requests/RequestsContext';
 import { useToastContext } from '@/features/toasts/ToastContext';
 import { ToastMessage } from '@/features/toasts/ToastMessage';
 import {
+  expertsQueryOptions,
   ownersQueryOptions,
   useAssignmentMutation,
   useFinishCloseoutMutation,
@@ -48,6 +49,7 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
   const navigate = useNavigate();
   const { identity, detailedIdentity } = useIdentityContext();
   const { data: owners } = useSuspenseQuery(ownersQueryOptions(identity));
+  const { data: experts } = useSuspenseQuery(expertsQueryOptions(identity));
   const { tab, nextId, previousId, setExpertsPanelOpen } = useRequestsContext();
   const { setShowToast, setToastMessage } = useToastContext();
   const [searchTerm, setSearchTerm] = useState('');
@@ -68,7 +70,27 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
         return [];
     }
   }, [owners, currentStep]);
+  const suggestedExperts = useMemo(() => {
+    switch (currentStep.stepIndex) {
+      case Steps.Lab:
+        return forwardOwners?.filter((owner) => {
+          const expert = experts?.find((expert) => expert.owner_id === owner.id);
+          console.log('Checking expert:', expert);
+          const hasExpertiseInRequestTopic = expert?.expertises.some((expertise) =>
+            request.topics.some((requestTopic) => requestTopic.id === expertise.topic.id)
+          );
+          return hasExpertiseInRequestTopic;
+        });
+      default:
+        return null;
+    }
+  }, [owners, currentStep]);
   const filteredOwners = useMemo(() => {
+    if (!searchTerm && suggestedExperts && suggestedExperts.length > 0) {
+      return forwardOwners?.filter(
+        (owner) => !suggestedExperts.some((suggested) => suggested.id === owner.id)
+      );
+    }
     if (!searchTerm) return forwardOwners ?? [];
     const lowerSearch = searchTerm.toLowerCase();
     return (forwardOwners ?? []).filter((owner) => {
@@ -231,7 +253,7 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
         onClose={handleAssignMenuClose}
         aria-labelledby="assign-menu-button"
       >
-        <Box sx={{ padding: 1 }}>
+        <Box sx={{ padding: 1, width: 300 }}>
           <TextField
             variant="outlined"
             size="small"
@@ -254,31 +276,70 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
             </ListItemText>
           </MenuItem>
         )}
-        {filteredOwners?.map((owner) => (
-          <MenuItem key={owner.id} onClick={() => handleForward(owner)}>
-            <Stack direction="row" spacing={1}>
-              <ListItemText>{owner.domain_name}</ListItemText>
-              <Chip label={capitalize(owner.domain_type)} size="small" />
-              {owner.domain_type === 'program' && (
-                <>
-                  {checkOrganizationTypes(owner) ? (
-                    <Tooltip
-                      title={`This program supports ${requestOrganizationType.name} customers.`}
-                    >
-                      <CheckCircleIcon color="success" />
-                    </Tooltip>
-                  ) : (
-                    <Tooltip
-                      title={`This program does not support ${requestOrganizationType.name} customers.`}
-                    >
-                      <ErrorIcon color="error" />
-                    </Tooltip>
-                  )}
-                </>
-              )}
-            </Stack>
-          </MenuItem>
-        ))}
+        {!searchTerm && suggestedExperts && (
+          <>
+            <Box sx={{ paddingX: 2, paddingY: 1 }}>
+              <Typography variant="subtitle2" color="text.secondary">
+                Suggested experts
+              </Typography>
+            </Box>
+            {suggestedExperts.length === 0 && (
+              <Box sx={{ paddingX: 2, paddingY: 1 }}>
+                <Typography variant="body2" color="text.secondary">
+                  No experts found with relevant expertise.
+                </Typography>
+              </Box>
+            )}
+            {suggestedExperts.length > 0 &&
+              suggestedExperts.map((owner) => (
+                <MenuItem key={owner.id} onClick={() => handleForward(owner)}>
+                  <Stack direction="row" spacing={1}>
+                    <ListItemText>{owner.domain_name}</ListItemText>
+                    <Chip label={capitalize(owner.domain_type)} size="small" />
+                  </Stack>
+                </MenuItem>
+              ))}
+            <Box sx={{ paddingX: 2, paddingY: 1 }}>
+              <Typography variant="subtitle2" color="text.secondary">
+                Other experts
+              </Typography>
+            </Box>
+          </>
+        )}
+        {filteredOwners &&
+          filteredOwners.length > 0 &&
+          filteredOwners.map((owner) => (
+            <MenuItem key={owner.id} onClick={() => handleForward(owner)}>
+              <Stack direction="row" spacing={1}>
+                <ListItemText>{owner.domain_name}</ListItemText>
+                <Chip label={capitalize(owner.domain_type)} size="small" />
+                {owner.domain_type === 'program' && (
+                  <>
+                    {checkOrganizationTypes(owner) ? (
+                      <Tooltip
+                        title={`This program supports ${requestOrganizationType.name} customers.`}
+                      >
+                        <CheckCircleIcon color="success" />
+                      </Tooltip>
+                    ) : (
+                      <Tooltip
+                        title={`This program does not support ${requestOrganizationType.name} customers.`}
+                      >
+                        <ErrorIcon color="error" />
+                      </Tooltip>
+                    )}
+                  </>
+                )}
+              </Stack>
+            </MenuItem>
+          ))}
+        {(!filteredOwners || filteredOwners.length === 0) && (
+          <Box sx={{ paddingX: 2, paddingY: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              No other experts found.
+            </Typography>
+          </Box>
+        )}
       </Menu>
     </>
   );

--- a/frontend/src/features/requests/RequestHeader.tsx
+++ b/frontend/src/features/requests/RequestHeader.tsx
@@ -89,7 +89,11 @@ export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
         sx={{ zIndex: 1202 }}
       >
         <Box sx={{ width: 1000 }}>
-          <ExpertsDataTable experts={experts || []} />
+          <ExpertsDataTable
+            experts={experts || []}
+            showAssignColumn
+            currentRequestId={request.id}
+          />
         </Box>
       </Drawer>
     </Stack>

--- a/frontend/src/features/requests/RequestHeader.tsx
+++ b/frontend/src/features/requests/RequestHeader.tsx
@@ -4,8 +4,12 @@ import { RequestAssignBackwardButton } from '@/features/requests/RequestAssignBa
 import { RequestAssignForwardButton } from '@/features/requests/RequestAssignForwardButton';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import { IconButton, Stack, Typography } from '@mui/material';
+import { IconButton, Stack, Typography, Drawer, Box } from '@mui/material';
 import { useRequestsContext } from './RequestsContext';
+import { ExpertsDataTable } from '@/features/experts/ExpertsDataTable';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { expertsQueryOptions } from '@/utils/queryOptions';
+import { useIdentityContext } from '@/features/identity/IdentityContext';
 
 interface RequestHeaderProps {
   request: TARequestDetail;
@@ -15,7 +19,13 @@ interface RequestHeaderProps {
  * Top header section to show in the request detail view
  */
 export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
-  const { tab, nextId, previousId } = useRequestsContext();
+  const { identity } = useIdentityContext();
+  const { tab, nextId, previousId, expertsPanelOpen, setExpertsPanelOpen } = useRequestsContext();
+  const { data: experts } = useSuspenseQuery(expertsQueryOptions(identity));
+
+  const handleCloseExpertsPanel = () => {
+    setExpertsPanelOpen(false);
+  };
 
   return (
     <Stack direction="row" alignItems="center" justifyContent="space-between">
@@ -72,6 +82,16 @@ export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
         <RequestAssignBackwardButton request={request} />
         <RequestAssignForwardButton request={request} />
       </Stack>
+      <Drawer
+        anchor="right"
+        open={expertsPanelOpen}
+        onClose={handleCloseExpertsPanel}
+        sx={{ zIndex: 1202 }}
+      >
+        <Box sx={{ width: 1000 }}>
+          <ExpertsDataTable experts={experts || []} />
+        </Box>
+      </Drawer>
     </Stack>
   );
 };

--- a/frontend/src/features/requests/RequestHeader.tsx
+++ b/frontend/src/features/requests/RequestHeader.tsx
@@ -1,15 +1,15 @@
 import { TARequestDetail } from '@/api/dashboard/types';
 import { AppLink } from '@/components/AppLink';
+import { ExpertsPanelDataTable } from '@/features/experts/ExpertsPanelDataTable';
+import { useIdentityContext } from '@/features/identity/IdentityContext';
 import { RequestAssignBackwardButton } from '@/features/requests/RequestAssignBackwardButton';
 import { RequestAssignForwardButton } from '@/features/requests/RequestAssignForwardButton';
+import { expertsQueryOptions } from '@/utils/queryOptions';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import { IconButton, Stack, Typography, Drawer, Box } from '@mui/material';
-import { useRequestsContext } from './RequestsContext';
-import { ExpertsDataTable } from '@/features/experts/ExpertsDataTable';
+import { Box, Drawer, IconButton, Stack, Typography } from '@mui/material';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { expertsQueryOptions } from '@/utils/queryOptions';
-import { useIdentityContext } from '@/features/identity/IdentityContext';
+import { useRequestsContext } from './RequestsContext';
 
 interface RequestHeaderProps {
   request: TARequestDetail;
@@ -89,11 +89,7 @@ export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
         sx={{ zIndex: 1202 }}
       >
         <Box sx={{ width: 1000 }}>
-          <ExpertsDataTable
-            experts={experts || []}
-            showAssignColumn
-            currentRequestId={request.id}
-          />
+          <ExpertsPanelDataTable experts={experts || []} currentRequestId={request.id} />
         </Box>
       </Drawer>
     </Stack>

--- a/frontend/src/features/requests/RequestsContext.tsx
+++ b/frontend/src/features/requests/RequestsContext.tsx
@@ -15,6 +15,8 @@ interface RequestsContextType {
   setSelectedListId: React.Dispatch<React.SetStateAction<string | null>>;
   searchTerm: string;
   setSearchTerm: (value: string) => void;
+  expertsPanelOpen: boolean;
+  setExpertsPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const RequestsContext = createContext<RequestsContextType | undefined>(undefined);
@@ -37,6 +39,7 @@ export const RequestsProvider: React.FC<RequestsProviderProps> = ({ tab, childre
   });
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedListId, setSelectedListId] = useState<string | null>(null);
+  const [expertsPanelOpen, setExpertsPanelOpen] = useState(false);
 
   const handleSetSortField = useCallback((value: string) => {
     localStorage.setItem(localStorageSortKey, value);
@@ -85,6 +88,8 @@ export const RequestsProvider: React.FC<RequestsProviderProps> = ({ tab, childre
       setSelectedListId,
       searchTerm,
       setSearchTerm: handleSetSearchTerm,
+      expertsPanelOpen,
+      setExpertsPanelOpen,
     };
   }, [
     currentIndex,
@@ -96,6 +101,8 @@ export const RequestsProvider: React.FC<RequestsProviderProps> = ({ tab, childre
     searchTerm,
     handleSetSearchTerm,
     tab,
+    expertsPanelOpen,
+    setExpertsPanelOpen,
   ]);
 
   return <RequestsContext value={value}>{children}</RequestsContext>;

--- a/frontend/src/features/requests/RequestsList.tsx
+++ b/frontend/src/features/requests/RequestsList.tsx
@@ -112,9 +112,11 @@ export const RequestsList: React.FC<RequestsListProps> = ({
           key={request.id}
           onClick={() => handleItemClick(request)}
           sx={{
-            backgroundColor: isSelected(request) ? 'primary.light' : 'white',
-            border: isSelected(request) ? '2px solid' : '1px solid',
-            borderColor: isSelected(request) ? 'primary.main' : 'grey.200',
+            backgroundColor: isSelected(request) ? 'success.light' : 'white',
+            border: isSelected(request) ? '1px solid' : '1px solid',
+            borderColor: isSelected(request) ? 'success.main' : 'grey.200',
+            borderLeft: isSelected(request) ? '6px solid' : '6px solid',
+            borderLeftColor: isSelected(request) ? 'success.main' : 'transparent',
             cursor: 'pointer',
             paddingBottom: 1,
             paddingLeft: 2,

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -30,7 +30,8 @@ export const theme = createTheme({
       main: '#38AECC',
     },
     success: {
-      main: '#74AA50',
+      main: '#13b8a6',
+      light: '#f0fdfa',
     },
     warning: {
       main: '#FAD038',


### PR DESCRIPTION
Resolves #185; resolves #160; resolves #206

The "Explore experts" button in the assign menu now opens up a panel with the experts table in it. There is a special column in this view with an "Assign" button you can click while exploring experts. I also added the Active Requests and Total Requests columns to the experts table.

<img width="1183" height="372" alt="Screenshot 2026-04-17 at 4 48 04 PM" src="https://github.com/user-attachments/assets/97e1989e-3e81-4acf-997d-d1ad2dd1c79d" />

There is also a new section in the assign menu when assigning experts which will group suggested experts together. A suggested expert is one where they have at least one expertise that matches at least one of the topics for that request.

<img width="520" height="336" alt="Screenshot 2026-04-17 at 4 47 18 PM" src="https://github.com/user-attachments/assets/0cdbc704-fdce-408e-ba3b-88bd3f1f3e64" />

The Experts page will now show experts to program leads so they can view/explore experts within their program.

Also fixes some bugs with saving topics and submitting intake forms.