### PR TITLE
Bugfixes for closeout form, experts menu, and email links

### DIFF
--- a/backend/api/core/serializers/expert.py
+++ b/backend/api/core/serializers/expert.py
@@ -13,4 +13,4 @@ class ExpertSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = "__all__"
+        fields = ["id", "name", "email", "owner_id"]

--- a/backend/api/core/util/email_prompts.py
+++ b/backend/api/core/util/email_prompts.py
@@ -38,7 +38,7 @@ def assignment_email(receipient_name: str, request: Request, customer: Customer)
     
     html_message = f"""
     <div>Hello {receipient_name},</div>
-    <p>You are receiving this email from TA Connect because <a href="{settings.FRONTEND_URL}/dashboard/requests/{request_id}" target="_blank">Request #{request_id}</a> has been assigned to {expert_str}{location_str}.</p>
+    <p>You are receiving this email from TA Connect because <a href="{settings.FRONTEND_URL}/requests/active/{request_id}" target="_blank">Request #{request_id}</a> has been assigned to {expert_str}{location_str}.</p>
     <p>
         <h2>Request Details</h2>
         <ul>
@@ -80,7 +80,7 @@ def new_request_email(receipient_name: str, request: Request, customer: Customer
 
     html_message = f"""
     <div>Hello {receipient_name},</div>
-    <p>A new request has been submitted into TA Connect and is awaiting your review: <a href=\"{settings.FRONTEND_URL}/dashboard/requests/{request.id}\" target=\"_blank\">Request #{request.id}</a>.</p>
+    <p>A new request has been submitted into TA Connect and is awaiting your review: <a href=\"{settings.FRONTEND_URL}/requests/active/{request.id}\" target=\"_blank\">Request #{request.id}</a>.</p>
     <p>
         <h2>Request Details</h2>
         <ul>

--- a/backend/api/core/views/expert.py
+++ b/backend/api/core/views/expert.py
@@ -68,14 +68,10 @@ class ExpertsListView(views.APIView):
         experts_data = []
         for assignment in expert_assignments:
             expert_user = assignment.user
-            data = {
-                "id": expert_user.pk,
-                "name": expert_user.name,
-                "email": expert_user.email,
-                "lab": LabSerializer(assignment.instance).data,
-                "program": ProgramSerializer(assignment.program).data,
-                "expertises": self._build_expertise_list(assignment),
-            }
+            data = dict(ExpertSerializer(expert_user).data)
+            data["lab"] = LabSerializer(assignment.instance).data
+            data["program"] = ProgramSerializer(assignment.program).data
+            data["expertises"] = self._build_expertise_list(assignment)
 
             expert_requests = Request.objects.filter(expert=expert_user)
             active_requests = expert_requests.exclude(owner=None)

--- a/frontend/src/features/requests/RequestAssignForwardButton.tsx
+++ b/frontend/src/features/requests/RequestAssignForwardButton.tsx
@@ -61,9 +61,8 @@ export const RequestAssignForwardButton: React.FC<RequestAssignForwardButtonProp
   const [searchTerm, setSearchTerm] = useState('');
   const requestOrganizationType = request.customers[0].org.type;
   const ownersContainsExperts =
-    owners?.some((owner) => owner.domain_type === 'expert') ||
-    request.status === 'assigned-to-lab' ||
-    request.status === 'rejected-by-expert';
+    owners?.some((owner) => owner.domain_type === 'expert') &&
+    (request.status === 'assigned-to-lab' || request.status === 'rejected-by-expert');
   const ownersNoun = useMemo(() => {
     switch (request.status) {
       case 'scoping':

--- a/frontend/src/features/requests/RequestAuditHistory.tsx
+++ b/frontend/src/features/requests/RequestAuditHistory.tsx
@@ -19,7 +19,6 @@ export const RequestAuditHistory: React.FC<RequestAuditHistoryProps> = ({ auditH
           flex: 2,
           minWidth: 300,
           renderCell: (params) => {
-            console.log('Rendering cell:', params);
             return (
               <Tooltip title={params.row.description} placement="top">
                 <span>{params.value}</span>

--- a/frontend/src/features/requests/RequestCloseoutForm.tsx
+++ b/frontend/src/features/requests/RequestCloseoutForm.tsx
@@ -37,11 +37,13 @@ import { ToastMessage } from '@/features/toasts/ToastMessage';
 
 interface RequestCloseoutFormProps {
   requestId: TARequestDetail['id'];
+  requestStatus: TARequestDetail['status'];
   expertOwnerId?: TAExpert['owner_id'];
 }
 
 export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
   requestId,
+  requestStatus,
   expertOwnerId,
 }) => {
   const { identity, detailedIdentity } = useIdentityContext();
@@ -197,22 +199,21 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
     followUpHasSameExpert,
   ]);
 
-  const approveButtonText = useMemo(() => {
-    if (
-      !closeoutForm?.submitted_date ||
-      (closeoutForm.approved_by_lab && closeoutForm.approved_by_program)
-    ) {
+  const labApproveButtonText = useMemo(() => {
+    if (!closeoutForm?.submitted_date || closeoutForm.approved_by_lab) {
       return null;
     } else if (!closeoutForm.approved_by_lab) {
       return 'Approve and send to program';
+    }
+  }, [closeoutForm?.submitted_date, closeoutForm?.approved_by_lab]);
+
+  const programApproveButtonText = useMemo(() => {
+    if (!closeoutForm?.submitted_date || closeoutForm.approved_by_program) {
+      return null;
     } else if (!closeoutForm.approved_by_program) {
       return 'Approve and mark completed';
     }
-  }, [
-    closeoutForm?.submitted_date,
-    closeoutForm?.approved_by_lab,
-    closeoutForm?.approved_by_program,
-  ]);
+  }, [closeoutForm?.submitted_date, closeoutForm?.approved_by_program]);
 
   const backwardButtonText = useMemo(() => {
     if (
@@ -481,21 +482,35 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
         <Button variant="outlined" onClick={handleDialogClose}>
           Back to request
         </Button>
-        {backwardButtonText && (
-          <Button variant="contained" color="error" onClick={handleBackward}>
-            {backwardButtonText}
-          </Button>
-        )}
+        {backwardButtonText &&
+          hasPermission('reject-closeout-form-by-lab', detailedIdentity, requestStatus) && (
+            <Button variant="contained" color="error" onClick={handleBackward}>
+              {backwardButtonText}
+            </Button>
+          )}
+        {backwardButtonText &&
+          hasPermission('reject-closeout-form-by-program', detailedIdentity, requestStatus) && (
+            <Button variant="contained" color="error" onClick={handleBackward}>
+              {backwardButtonText}
+            </Button>
+          )}
         {!closeoutForm.submitted_date && hasPermission('edit-closeout-form', detailedIdentity) && (
           <Button variant="contained" color="primary" type="submit" form="closeout-form">
             Submit for review
           </Button>
         )}
-        {approveButtonText && closeoutForm.submitted_date && (
-          <Button variant="contained" color="primary" onClick={handleApprove}>
-            {approveButtonText}
-          </Button>
-        )}
+        {labApproveButtonText &&
+          hasPermission('approve-closeout-form-by-lab', detailedIdentity) && (
+            <Button variant="contained" color="primary" onClick={handleApprove}>
+              {labApproveButtonText}
+            </Button>
+          )}
+        {programApproveButtonText &&
+          hasPermission('approve-closeout-form-by-program', detailedIdentity) && (
+            <Button variant="contained" color="primary" onClick={handleApprove}>
+              {programApproveButtonText}
+            </Button>
+          )}
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/features/requests/RequestCloseoutForm.tsx
+++ b/frontend/src/features/requests/RequestCloseoutForm.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/api/queryOptions';
 import { useIdentityContext } from '@/features/identity/IdentityContext';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { parseBoolean } from '@/utils/utils';
+import { hasPermission, parseBoolean } from '@/utils/utils';
 import { useToastContext } from '@/features/toasts/ToastContext';
 import { queryClient } from '@/App';
 import { ToastMessage } from '@/features/toasts/ToastMessage';
@@ -44,7 +44,7 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
   requestId,
   expertOwnerId,
 }) => {
-  const { identity } = useIdentityContext();
+  const { identity, detailedIdentity } = useIdentityContext();
   const { closeoutDialogOpen, setCloseoutDialogOpen } = useRequestsContext();
   const { setShowToast, setToastMessage } = useToastContext();
   const { data: closeoutForm } = useSuspenseQuery(
@@ -278,6 +278,10 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
     return () => clearTimeout(timeout);
   }, [handleSave, closeoutDialogOpen]);
 
+  if (!closeoutForm) {
+    return null;
+  }
+
   return (
     <Dialog
       fullWidth
@@ -290,7 +294,8 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
         Closeout Questions for Expert
       </DialogTitle>
       <DialogContent>
-        {closeoutForm?.submitted_date && (
+        {(closeoutForm.submitted_date ||
+          !hasPermission('edit-closeout-form', detailedIdentity)) && (
           <Stack spacing={3} sx={{ marginTop: 2 }}>
             <Stack spacing={1}>
               <Typography variant="subtitle1" fontWeight="bold">
@@ -354,7 +359,7 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
             </Stack>
           </Stack>
         )}
-        {!closeoutForm?.submitted_date && (
+        {!closeoutForm.submitted_date && hasPermission('edit-closeout-form', detailedIdentity) && (
           <form onSubmit={handleSubmit} id="closeout-form">
             <Stack spacing={3} sx={{ marginTop: 2 }}>
               <Typography>
@@ -481,12 +486,12 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
             {backwardButtonText}
           </Button>
         )}
-        {!closeoutForm?.submitted_date && (
+        {!closeoutForm.submitted_date && hasPermission('edit-closeout-form', detailedIdentity) && (
           <Button variant="contained" color="primary" type="submit" form="closeout-form">
             Submit for review
           </Button>
         )}
-        {approveButtonText && closeoutForm?.submitted_date && (
+        {approveButtonText && closeoutForm.submitted_date && (
           <Button variant="contained" color="primary" onClick={handleApprove}>
             {approveButtonText}
           </Button>

--- a/frontend/src/features/requests/RequestHeader.tsx
+++ b/frontend/src/features/requests/RequestHeader.tsx
@@ -95,7 +95,11 @@ export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
         </Box>
       </Drawer>
       <RequestDatesDialog request={request} />
-      <RequestCloseoutForm requestId={request.id} expertOwnerId={request.expert?.owner_id} />
+      <RequestCloseoutForm
+        requestId={request.id}
+        requestStatus={request.status}
+        expertOwnerId={request.expert?.owner_id}
+      />
     </Stack>
   );
 };

--- a/frontend/src/features/requests/RequestNotes.tsx
+++ b/frontend/src/features/requests/RequestNotes.tsx
@@ -121,7 +121,7 @@ export const RequestNotes: React.FC<RequestNotesProps> = ({ requestId, notes }) 
               <Stack sx={{ paddingTop: 2 }}>
                 <TextField
                   value={noteDescription}
-                  label="Description"
+                  label="Message"
                   multiline
                   rows={4}
                   onChange={handleDescriptionChange}

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -96,7 +96,8 @@ type PermissionAction =
   | 'edit-projected-completion-date'
   | 'edit-actual-completion-date'
   | 'edit-customer'
-  | 'edit-organization-type';
+  | 'edit-organization-type'
+  | 'edit-closeout-form';
 
 /**
  * Frontend function for checking if a user has permission to perform a certain action based on their role.
@@ -173,6 +174,7 @@ export const hasPermission = (
         case 'edit-projected-start-date':
         case 'edit-projected-completion-date':
         case 'edit-actual-completion-date':
+        case 'edit-closeout-form':
           return true;
       }
       return false;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -97,7 +97,11 @@ type PermissionAction =
   | 'edit-actual-completion-date'
   | 'edit-customer'
   | 'edit-organization-type'
-  | 'edit-closeout-form';
+  | 'edit-closeout-form'
+  | 'approve-closeout-form-by-lab'
+  | 'approve-closeout-form-by-program'
+  | 'reject-closeout-form-by-lab'
+  | 'reject-closeout-form-by-program';
 
 /**
  * Frontend function for checking if a user has permission to perform a certain action based on their role.
@@ -118,6 +122,16 @@ export const hasPermission = (
     statusName !== 'assigned-to-expert' &&
     statusName !== 'providing-ta'
   ) {
+    return false;
+  }
+
+  // Only allow rejecting closeout by lab if the current status is "closeout-review-by-lab"
+  if (action === 'reject-closeout-form-by-lab' && statusName !== 'closeout-review-by-lab') {
+    return false;
+  }
+
+  // Only allow rejecting closeout by program if the current status is "closeout-review-by-program"
+  if (action === 'reject-closeout-form-by-program' && statusName !== 'closeout-review-by-program') {
     return false;
   }
 
@@ -151,6 +165,8 @@ export const hasPermission = (
         case 'edit-projected-completion-date':
         case 'edit-actual-completion-date':
         case 'edit-customer':
+        case 'approve-closeout-form-by-program':
+        case 'reject-closeout-form-by-program':
           return true;
       }
       return false;
@@ -166,6 +182,8 @@ export const hasPermission = (
         case 'edit-projected-completion-date':
         case 'edit-actual-completion-date':
         case 'edit-customer':
+        case 'approve-closeout-form-by-lab':
+        case 'reject-closeout-form-by-lab':
           return true;
       }
       return false;


### PR DESCRIPTION
Resolves #226 

Fixes several different bugs:
- The closeout form now shows in read-only mode if you don't have permission to edit it (even if it is still being worked on by the expert)
- Closeout buttons are hidden by permissions
- Expert assignment from table is fixed
- Email links in assignment notifications used the old path