### PR TITLE
Implement role management UI and backend

### DIFF
--- a/backend/api/core/urls.py
+++ b/backend/api/core/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
 
     path('users/<int:user_id>', UserEditView.as_view(), name="user-edit"),
     path('identities/', IdentityListView.as_view(), name="identities-list"),
+    path('manageable-roles/', ManageableRoleListView.as_view(), name="manageable-roles-list"),
     path('statuses/', StatusListView.as_view(), name="statuses-list"),
     path('experts/', ExpertsListView.as_view(), name="experts-list"),
     path('depths/', DepthListView.as_view(), name="depth-list"),

--- a/backend/api/core/views/__init__.py
+++ b/backend/api/core/views/__init__.py
@@ -19,6 +19,7 @@ from .audit_history import AuditHistoryListView
 from .user import UserEditView
 from .closeout_form import CloseoutFormView
 from .expertise import ExpertiseUpdateView
+from .manageable_role import ManageableRoleListView
 
 __all__ = [
     "AssignmentView",
@@ -59,4 +60,5 @@ __all__ = [
     "UserEditView",
     "CloseoutFormView",
     "ExpertiseUpdateView",
+    "ManageableRoleListView",
 ]

--- a/backend/api/core/views/manageable_role.py
+++ b/backend/api/core/views/manageable_role.py
@@ -1,0 +1,215 @@
+from django.db.models import Q
+from rest_framework import authentication, permissions, status, views
+from rest_framework.response import Response
+
+from allauth.headless.contrib.rest_framework.authentication import XSessionTokenAuthentication
+
+from core.constants import ROLE
+from core.models import Expertise, Lab, LabRoleAssignment, Program, ProgramRoleAssignment, Role, SystemRoleAssignment, User
+from core.serializers import LabSerializer, ProgramSerializer, RoleSerializer
+
+
+def _user_data(user):
+    return {"id": user.id, "email": user.email, "name": user.name}
+
+
+def _assignment_data(assignment, location):
+    data = {
+        "assignment_id": assignment.id,
+        "location": location,
+        "user": _user_data(assignment.user),
+        "role": RoleSerializer(assignment.role).data,
+        "date_assigned": assignment.date_assigned,
+    }
+    if location == "program":
+        data["instance"] = ProgramSerializer(assignment.instance).data
+    if location == "lab":
+        data["instance"] = LabSerializer(assignment.instance).data
+        data["program"] = ProgramSerializer(assignment.program).data
+    return data
+
+
+class ManageableRoleListView(views.APIView):
+    authentication_classes = [
+        authentication.SessionAuthentication,
+        XSessionTokenAuthentication,
+    ]
+
+    permission_classes = [
+        permissions.IsAuthenticated,
+    ]
+
+    def _is_admin(self, request):
+        return SystemRoleAssignment.objects.filter(user=request.user, role__name=ROLE.ADMIN).exists()
+
+    def _managed_program_ids(self, request):
+        if self._is_admin(request):
+            return list(Program.objects.values_list("id", flat=True))
+        return list(
+            ProgramRoleAssignment.objects.filter(
+                user=request.user,
+                role__name=ROLE.PROGRAM_LEAD,
+            ).values_list("instance_id", flat=True)
+        )
+
+    def _can_manage_program(self, request, program_id):
+        return self._is_admin(request) or program_id in self._managed_program_ids(request)
+
+    def _manageable_role_names(self, request):
+        names = [ROLE.EXPERT, ROLE.LAB_LEAD]
+        if self._is_admin(request):
+            names.append(ROLE.PROGRAM_LEAD)
+        return names
+
+    def _role_is_manageable(self, request, role, location):
+        if location == "program":
+            return self._is_admin(request) and role.name == ROLE.PROGRAM_LEAD
+        return role.name in [ROLE.EXPERT, ROLE.LAB_LEAD]
+
+    def _get_lab_program_id(self, lab_id, explicit_program_id=None):
+        if explicit_program_id:
+            program = Program.objects.filter(pk=explicit_program_id, labs__id=lab_id).first()
+        else:
+            program = Program.objects.filter(labs__id=lab_id).first()
+        return program.id if program else None
+
+    def get(self, request, format=None):
+        program_ids = self._managed_program_ids(request)
+        if not program_ids:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        program_assignments = ProgramRoleAssignment.objects.none()
+        if self._is_admin(request):
+            program_assignments = ProgramRoleAssignment.objects.filter(
+                instance_id__in=program_ids,
+                role__name__in=[ROLE.PROGRAM_LEAD],
+            ).select_related("user", "role", "instance")
+        lab_assignments = LabRoleAssignment.objects.filter(
+            program_id__in=program_ids,
+            role__name__in=[ROLE.EXPERT, ROLE.LAB_LEAD],
+        ).select_related("user", "role", "instance", "program")
+
+        programs = Program.objects.filter(id__in=program_ids).prefetch_related("labs")
+        labs = Lab.objects.filter(programs__id__in=program_ids).distinct()
+        users = User.objects.filter(
+            Q(programroleassignment__instance_id__in=program_ids)
+            | Q(labroleassignment__program_id__in=program_ids)
+            | Q(systemroleassignment__role__name=ROLE.ADMIN)
+        ).distinct()
+        if self._is_admin(request):
+            users = User.objects.all()
+
+        assignments = [
+            *[_assignment_data(assignment, "program") for assignment in program_assignments],
+            *[_assignment_data(assignment, "lab") for assignment in lab_assignments],
+        ]
+
+        return Response(
+            data={
+                "assignments": assignments,
+                "users": [_user_data(user) for user in users.order_by("name", "email")],
+                "programs": ProgramSerializer(programs.order_by("name"), many=True).data,
+                "labs": LabSerializer(labs.order_by("name"), many=True).data,
+                "roles": RoleSerializer(
+                    Role.objects.filter(name__in=self._manageable_role_names(request)).order_by("name"),
+                    many=True,
+                ).data,
+                "is_admin": self._is_admin(request),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    def post(self, request, format=None):
+        role = Role.objects.filter(pk=request.data.get("role")).first()
+        user = User.objects.filter(pk=request.data.get("user")).first()
+        location = request.data.get("location")
+        program_id = request.data.get("program")
+        lab_id = request.data.get("lab")
+
+        if not role or not user or not self._role_is_manageable(request, role, location):
+            return Response(data={"message": "Invalid user or role."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if location == "program":
+            if not self._can_manage_program(request, program_id):
+                return Response(data={"message": "You do not have permission to manage this program."}, status=status.HTTP_403_FORBIDDEN)
+            program = Program.objects.filter(pk=program_id).first()
+            if not program:
+                return Response(data={"message": "Invalid program."}, status=status.HTTP_400_BAD_REQUEST)
+            assignment, _ = ProgramRoleAssignment.objects.get_or_create(user=user, role=role, instance=program)
+            return Response(data=_assignment_data(assignment, "program"), status=status.HTTP_201_CREATED)
+
+        if location == "lab":
+            resolved_program_id = self._get_lab_program_id(lab_id, program_id)
+            if not resolved_program_id or not self._can_manage_program(request, resolved_program_id):
+                return Response(data={"message": "You do not have permission to manage this lab."}, status=status.HTTP_403_FORBIDDEN)
+            lab = Lab.objects.filter(pk=lab_id).first()
+            program = Program.objects.filter(pk=resolved_program_id).first()
+            assignment, _ = LabRoleAssignment.objects.get_or_create(user=user, role=role, instance=lab, program=program)
+            return Response(data=_assignment_data(assignment, "lab"), status=status.HTTP_201_CREATED)
+
+        return Response(data={"message": "Invalid role location."}, status=status.HTTP_400_BAD_REQUEST)
+
+    def patch(self, request, format=None):
+        assignment_id = request.data.get("assignment_id")
+        location = request.data.get("location")
+        user = User.objects.filter(pk=request.data.get("user")).first()
+        role = Role.objects.filter(pk=request.data.get("role")).first()
+
+        if not user or not role or not self._role_is_manageable(request, role, location):
+            return Response(data={"message": "Invalid user or role."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if location == "program":
+            assignment = ProgramRoleAssignment.objects.filter(pk=assignment_id).first()
+            program = Program.objects.filter(pk=request.data.get("program")).first()
+            if not assignment or not program:
+                return Response(data={"message": "Invalid assignment or program."}, status=status.HTTP_400_BAD_REQUEST)
+            if not self._can_manage_program(request, assignment.instance_id) or not self._can_manage_program(request, program.id):
+                return Response(data={"message": "You do not have permission to edit this assignment."}, status=status.HTTP_403_FORBIDDEN)
+            assignment.user = user
+            assignment.role = role
+            assignment.instance = program
+            assignment.save()
+            return Response(data=_assignment_data(assignment, "program"), status=status.HTTP_200_OK)
+
+        if location == "lab":
+            assignment = LabRoleAssignment.objects.filter(pk=assignment_id).first()
+            lab = Lab.objects.filter(pk=request.data.get("lab")).first()
+            program_id = self._get_lab_program_id(request.data.get("lab"), request.data.get("program"))
+            program = Program.objects.filter(pk=program_id).first()
+            if not assignment or not lab or not program:
+                return Response(data={"message": "Invalid assignment, lab, or program."}, status=status.HTTP_400_BAD_REQUEST)
+            if not self._can_manage_program(request, assignment.program_id) or not self._can_manage_program(request, program.id):
+                return Response(data={"message": "You do not have permission to edit this assignment."}, status=status.HTTP_403_FORBIDDEN)
+            Expertise.objects.filter(lab_role_assignment=assignment).delete()
+            assignment.user = user
+            assignment.role = role
+            assignment.instance = lab
+            assignment.program = program
+            assignment.save()
+            return Response(data=_assignment_data(assignment, "lab"), status=status.HTTP_200_OK)
+
+        return Response(data={"message": "Invalid role location."}, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, format=None):
+        assignment_id = request.data.get("assignment_id")
+        location = request.data.get("location")
+        if location == "program":
+            assignment = ProgramRoleAssignment.objects.filter(pk=assignment_id).first()
+            if not assignment:
+                return Response(data={"message": "Invalid assignment."}, status=status.HTTP_404_NOT_FOUND)
+            if not self._can_manage_program(request, assignment.instance_id):
+                return Response(data={"message": "You do not have permission to revoke this assignment."}, status=status.HTTP_403_FORBIDDEN)
+            assignment.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        if location == "lab":
+            assignment = LabRoleAssignment.objects.filter(pk=assignment_id).first()
+            if not assignment:
+                return Response(data={"message": "Invalid assignment."}, status=status.HTTP_404_NOT_FOUND)
+            if not self._can_manage_program(request, assignment.program_id):
+                return Response(data={"message": "You do not have permission to revoke this assignment."}, status=status.HTTP_403_FORBIDDEN)
+            Expertise.objects.filter(lab_role_assignment=assignment).delete()
+            assignment.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        return Response(data={"message": "Invalid role location."}, status=status.HTTP_400_BAD_REQUEST)

--- a/frontend/src/api/dashboard/index.ts
+++ b/frontend/src/api/dashboard/index.ts
@@ -148,15 +148,17 @@ export async function postForm(
   }
 }
 
-export async function deleteData(url: string, isAdminMode?: boolean): Promise<void> {
+export async function deleteData<T>(url: string, isAdminMode?: boolean, data?: T): Promise<void> {
   try {
     const response = await fetch(url, {
       method: 'DELETE',
       credentials: 'include',
       headers: {
+        'Content-Type': 'application/json',
         'X-CSRFToken': getCSRFToken() || '',
         'X-Admin-Mode': isAdminMode ? 'true' : 'false',
       },
+      body: data != null ? JSON.stringify(data) : undefined,
     });
 
     if (!response.ok) {

--- a/frontend/src/api/dashboard/types.ts
+++ b/frontend/src/api/dashboard/types.ts
@@ -306,6 +306,43 @@ export interface TAIdentity {
   expertises?: TAExpertise[];
 }
 
+export interface TAManageableRoleAssignment extends TAIdentity {
+  date_assigned: string;
+  user: {
+    id: number;
+    email: string;
+    name?: string;
+  };
+}
+
+export interface TAManageableRoleUser {
+  id: number;
+  email: string;
+  name?: string;
+}
+
+export interface TAManageableRolesResponse {
+  assignments: TAManageableRoleAssignment[];
+  users: TAManageableRoleUser[];
+  programs: TAProgram[];
+  labs: TALab[];
+  roles: {
+    id: number;
+    name: TARole;
+    description: string;
+  }[];
+  is_admin: boolean;
+}
+
+export interface TAManageableRoleMutation {
+  assignment_id?: number;
+  location: 'program' | 'lab';
+  user: number;
+  role: number;
+  program?: number;
+  lab?: number;
+}
+
 export interface TAUser {
   display: string;
   has_usable_password: boolean;

--- a/frontend/src/api/queryOptions.tsx
+++ b/frontend/src/api/queryOptions.tsx
@@ -207,7 +207,7 @@ export const useManageableRoleCreateMutation = () => {
     mutationKey: ['manageableRoles', 'create'],
     mutationFn: (data: TAManageableRoleMutation) =>
       postData<TAManageableRoleMutation>(`${apiUrl}/manageable-roles/`, data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['manageableRoles'] }),
+    onSuccess: () => queryClient.invalidateQueries(),
   });
 };
 
@@ -216,7 +216,7 @@ export const useManageableRoleUpdateMutation = () => {
     mutationKey: ['manageableRoles', 'update'],
     mutationFn: (data: TAManageableRoleMutation) =>
       patchData<TAManageableRoleMutation>(`${apiUrl}/manageable-roles/`, data),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['manageableRoles'] }),
+    onSuccess: () => queryClient.invalidateQueries(),
   });
 };
 
@@ -237,7 +237,7 @@ export const useManageableRoleDeleteMutation = () => {
         throw Error(`Request status: ${response.status}`);
       }
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['manageableRoles'] }),
+    onSuccess: () => queryClient.invalidateQueries(),
   });
 };
 

--- a/frontend/src/api/queryOptions.tsx
+++ b/frontend/src/api/queryOptions.tsx
@@ -35,7 +35,6 @@ import { sessionsApi } from '@/api/sessions';
 import { queryClient } from '@/App';
 import { useToastContext } from '@/features/toasts/ToastContext';
 import { ToastMessage } from '@/features/toasts/ToastMessage';
-import { getCSRFToken } from '@/utils/cookies';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import { queryOptions, useMutation, UseMutationOptions } from '@tanstack/react-query';
@@ -223,20 +222,8 @@ export const useManageableRoleUpdateMutation = () => {
 export const useManageableRoleDeleteMutation = () => {
   return useMutation({
     mutationKey: ['manageableRoles', 'delete'],
-    mutationFn: async (data: Pick<TAManageableRoleMutation, 'assignment_id' | 'location'>) => {
-      const response = await fetch(`${apiUrl}/manageable-roles/`, {
-        method: 'DELETE',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCSRFToken() || '',
-        },
-        body: JSON.stringify(data),
-      });
-      if (!response.ok) {
-        throw Error(`Request status: ${response.status}`);
-      }
-    },
+    mutationFn: (data: Pick<TAManageableRoleMutation, 'assignment_id' | 'location'>) =>
+      deleteData(`${apiUrl}/manageable-roles/`, false, data),
     onSuccess: () => queryClient.invalidateQueries(),
   });
 };

--- a/frontend/src/api/queryOptions.tsx
+++ b/frontend/src/api/queryOptions.tsx
@@ -10,6 +10,8 @@ import {
   TACustomerTransferMutation,
   TAExpert,
   TAIdentity,
+  TAManageableRoleMutation,
+  TAManageableRolesResponse,
   TANote,
   TAOrganization,
   TAOrganizationMutation,
@@ -33,6 +35,7 @@ import { sessionsApi } from '@/api/sessions';
 import { queryClient } from '@/App';
 import { useToastContext } from '@/features/toasts/ToastContext';
 import { ToastMessage } from '@/features/toasts/ToastMessage';
+import { getCSRFToken } from '@/utils/cookies';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import { queryOptions, useMutation, UseMutationOptions } from '@tanstack/react-query';
@@ -58,6 +61,13 @@ export const identitiesQueryOptions = () =>
     staleTime: 120_000, // stale after 2 minutes
     queryKey: ['identities'],
     queryFn: () => fetchData<TAIdentity[]>(`${apiUrl}/identities/`),
+  });
+
+export const manageableRolesQueryOptions = () =>
+  queryOptions({
+    staleTime: 120_000,
+    queryKey: ['manageableRoles'],
+    queryFn: () => fetchData<TAManageableRolesResponse>(`${apiUrl}/manageable-roles/`),
   });
 
 export const requestsQueryOptions = (isAdminMode?: boolean) =>
@@ -189,6 +199,45 @@ export const useExpertiseMutation = (labRoleAssignmentId: string) => {
         data
       ),
     onSuccess: () => queryClient.invalidateQueries(),
+  });
+};
+
+export const useManageableRoleCreateMutation = () => {
+  return useMutation({
+    mutationKey: ['manageableRoles', 'create'],
+    mutationFn: (data: TAManageableRoleMutation) =>
+      postData<TAManageableRoleMutation>(`${apiUrl}/manageable-roles/`, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['manageableRoles'] }),
+  });
+};
+
+export const useManageableRoleUpdateMutation = () => {
+  return useMutation({
+    mutationKey: ['manageableRoles', 'update'],
+    mutationFn: (data: TAManageableRoleMutation) =>
+      patchData<TAManageableRoleMutation>(`${apiUrl}/manageable-roles/`, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['manageableRoles'] }),
+  });
+};
+
+export const useManageableRoleDeleteMutation = () => {
+  return useMutation({
+    mutationKey: ['manageableRoles', 'delete'],
+    mutationFn: async (data: Pick<TAManageableRoleMutation, 'assignment_id' | 'location'>) => {
+      const response = await fetch(`${apiUrl}/manageable-roles/`, {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCSRFToken() || '',
+        },
+        body: JSON.stringify(data),
+      });
+      if (!response.ok) {
+        throw Error(`Request status: ${response.status}`);
+      }
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['manageableRoles'] }),
   });
 };
 

--- a/frontend/src/features/profile/RoleDeleteDialog.tsx
+++ b/frontend/src/features/profile/RoleDeleteDialog.tsx
@@ -1,0 +1,120 @@
+import { TAManageableRoleAssignment } from '@/api/dashboard/types';
+import { useManageableRoleDeleteMutation } from '@/api/queryOptions';
+import { useToastContext } from '@/features/toasts/ToastContext';
+import { ToastMessage } from '@/features/toasts/ToastMessage';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import { CircularProgress, Stack } from '@mui/material';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import * as React from 'react';
+import { useEffect } from 'react';
+
+interface RoleDeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  roleAssignment: TAManageableRoleAssignment | null;
+}
+
+export const RoleDeleteDialog: React.FC<RoleDeleteDialogProps> = ({
+  open,
+  onClose,
+  roleAssignment,
+}) => {
+  const deleteRoleMutation = useManageableRoleDeleteMutation();
+  const { setShowToast, setToastMessage, setToastAutoHideDuration } = useToastContext();
+
+  /**
+   * Revoke the selected role assignment after user confirmation.
+   */
+  const handleConfirm = () => {
+    if (!roleAssignment) {
+      return;
+    }
+
+    deleteRoleMutation.mutate({
+      assignment_id: roleAssignment.assignment_id,
+      location: roleAssignment.location as 'program' | 'lab',
+    });
+    onClose();
+  };
+
+  const handleCancel = () => {
+    onClose();
+  };
+
+  useEffect(() => {
+    if (deleteRoleMutation.isPending) {
+      setShowToast(true);
+      setToastAutoHideDuration(null);
+      setToastMessage(<ToastMessage icon={<CircularProgress />}>Revoking role</ToastMessage>);
+    } else if (deleteRoleMutation.isSuccess) {
+      setShowToast(true);
+      setToastAutoHideDuration(6000);
+      setToastMessage(<ToastMessage icon={<CheckCircleIcon />}>Role revoked</ToastMessage>);
+    } else if (deleteRoleMutation.isError) {
+      setShowToast(true);
+      setToastAutoHideDuration(6000);
+      setToastMessage(
+        <ToastMessage icon={<ErrorIcon />}>{deleteRoleMutation.error.message}</ToastMessage>
+      );
+    }
+  }, [
+    deleteRoleMutation.isPending,
+    deleteRoleMutation.isSuccess,
+    deleteRoleMutation.isError,
+    deleteRoleMutation.error?.message,
+  ]);
+
+  if (!roleAssignment) {
+    return null;
+  }
+
+  const assigneeName = roleAssignment.user.name || roleAssignment.user.email;
+  const scopeName =
+    roleAssignment.location === 'program'
+      ? roleAssignment.program?.name || roleAssignment.instance?.name
+      : roleAssignment.instance?.name || roleAssignment.program?.name;
+
+  return (
+    <Dialog open={open} maxWidth="sm" fullWidth onClose={handleCancel} disableRestoreFocus>
+      <DialogTitle>Revoke Role</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Are you sure you want to revoke the <strong>{roleAssignment.role.name}</strong> role from{' '}
+          <strong>{assigneeName}</strong>?
+        </DialogContentText>
+        <DialogContentText sx={{ mt: 2 }}>
+          This action cannot be undone. This will remove their {roleAssignment.location} access
+          {scopeName ? (
+            <>
+              {' '}
+              for <strong>{scopeName}</strong>
+            </>
+          ) : (
+            ''
+          )}
+          .
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ justifyContent: 'space-between' }}>
+        <span></span>
+        <Stack direction="row">
+          <Button onClick={handleCancel}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleConfirm}
+            disabled={deleteRoleMutation.isPending}
+          >
+            Revoke
+          </Button>
+        </Stack>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/features/profile/RolePanel.tsx
+++ b/frontend/src/features/profile/RolePanel.tsx
@@ -27,9 +27,9 @@ export const RolePanel: React.FC<RolePanelProps> = ({
 
   return (
     <Paper sx={{ height: '100%', padding: 2 }}>
-      <Stack>
+      <Stack spacing={1}>
         <Stack spacing={0}>
-          <Typography variant="h5" fontWeight="bold" color="primary">
+          <Typography fontWeight="bold" color="primary">
             {identity.role.name}
           </Typography>
           <Typography variant="body2" color="text.secondary">
@@ -37,27 +37,36 @@ export const RolePanel: React.FC<RolePanelProps> = ({
           </Typography>
         </Stack>
         {identity.program && (
-          <Stack spacing={0}>
-            <Typography fontWeight="bold">Program: {identity.program.name}</Typography>
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            sx={{ paddingTop: 1, borderTop: '1px solid', borderTopColor: 'divider' }}
+          >
+            <Typography variant="body2" fontWeight="bold">
+              Program:
+            </Typography>
             <Typography variant="body2" color="text.secondary">
-              {identity.program.description}
+              {identity.program.name} ({identity.program.description})
             </Typography>
           </Stack>
         )}
         {identity.instance && (
-          <Stack spacing={0}>
-            <Typography fontWeight="bold">
-              {capitalize(identity.location)}: {identity.instance.name}
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="body2" fontWeight="bold">
+              {capitalize(identity.location)}:
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {identity.instance.description}
+              {identity.instance.name} ({identity.instance.description})
             </Typography>
           </Stack>
         )}
         {identity.expertises && (
           <Stack spacing={1}>
             <Stack direction="row" spacing={1} alignItems="center">
-              <Typography fontWeight="bold">Expertises</Typography>
+              <Typography variant="body2" fontWeight="bold">
+                Expertises
+              </Typography>
               <IconButton size="small" onClick={handleEditExpertises}>
                 <EditIcon />
               </IconButton>
@@ -68,7 +77,7 @@ export const RolePanel: React.FC<RolePanelProps> = ({
                   <Grid key={expertise.id}>
                     <Tooltip
                       title={`${expertise.topic.name} (${expertise.depth.name})`}
-                      placement="left"
+                      placement="top"
                     >
                       <Chip label={expertise.topic.name} sx={{ maxWidth: 175 }} />
                     </Tooltip>

--- a/frontend/src/features/profile/RolesGrid.tsx
+++ b/frontend/src/features/profile/RolesGrid.tsx
@@ -34,13 +34,13 @@ export const RolesGrid: React.FC<RolesGridProps> = ({ identities }) => {
   return (
     <Stack spacing={4}>
       <Stack>
-        <Typography variant="h5" component="h3">
-          System Roles
+        <Typography variant="h4" component="h2" fontWeight="bold">
+          My System Roles
         </Typography>
         {systemIdentities.length > 0 && (
           <Grid container spacing={2}>
             {systemIdentities.map((identity) => (
-              <Grid size={{ lg: 4, md: 6, xs: 12 }} key={getIdentityKey(identity)}>
+              <Grid size={{ lg: 12, md: 12, xs: 12 }} key={getIdentityKey(identity)}>
                 <RolePanel
                   identity={identity}
                   setExpertisesDialogOpen={setExpertisesDialogOpen}
@@ -50,15 +50,20 @@ export const RolesGrid: React.FC<RolesGridProps> = ({ identities }) => {
             ))}
           </Grid>
         )}
+        {systemIdentities.length === 0 && (
+          <Typography variant="body1" color="text.secondary">
+            You don't have any system roles assigned yet.
+          </Typography>
+        )}
       </Stack>
       <Stack>
-        <Typography variant="h5" component="h3">
-          Organizational Roles
+        <Typography variant="h4" component="h2" fontWeight="bold">
+          My Organizational Roles
         </Typography>
         {organizationalIdentities.length > 0 && (
           <Grid container spacing={2}>
             {organizationalIdentities.map((identity) => (
-              <Grid size={{ lg: 4, md: 6, xs: 12 }} key={getIdentityKey(identity)}>
+              <Grid size={{ lg: 12, md: 12, xs: 12 }} key={getIdentityKey(identity)}>
                 <RolePanel
                   identity={identity}
                   setExpertisesDialogOpen={setExpertisesDialogOpen}
@@ -69,6 +74,11 @@ export const RolesGrid: React.FC<RolesGridProps> = ({ identities }) => {
               </Grid>
             ))}
           </Grid>
+        )}
+        {organizationalIdentities.length === 0 && (
+          <Typography variant="body1" color="text.secondary">
+            You don't have any organizational roles assigned yet.
+          </Typography>
         )}
       </Stack>
       {editingLabRoleAssignmentId && (

--- a/frontend/src/features/profile/RolesManager.tsx
+++ b/frontend/src/features/profile/RolesManager.tsx
@@ -1,0 +1,312 @@
+import {
+  manageableRolesQueryOptions,
+  useManageableRoleCreateMutation,
+  useManageableRoleDeleteMutation,
+  useManageableRoleUpdateMutation,
+} from '@/api/queryOptions';
+import {
+  TAManageableRoleAssignment,
+  TAManageableRoleMutation,
+  TAManageableRolesResponse,
+  TARole,
+} from '@/api/dashboard/types';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+
+const emptyForm: TAManageableRoleMutation = {
+  location: 'lab',
+  user: 0,
+  role: 0,
+  program: undefined,
+  lab: undefined,
+};
+
+const toForm = (assignment: TAManageableRoleAssignment): TAManageableRoleMutation => ({
+  assignment_id: assignment.assignment_id,
+  location: assignment.location as 'program' | 'lab',
+  user: assignment.user.id,
+  role: assignment.role.id,
+  program: assignment.location === 'program' ? assignment.instance?.id : assignment.program?.id,
+  lab: assignment.location === 'lab' ? assignment.instance?.id : undefined,
+});
+
+export const RolesManager: React.FC = () => {
+  const { data } = useSuspenseQuery(manageableRolesQueryOptions());
+  const manageableRoles = data as TAManageableRolesResponse | null;
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [form, setForm] = useState<TAManageableRoleMutation>(emptyForm);
+
+  const createMutation = useManageableRoleCreateMutation();
+  const updateMutation = useManageableRoleUpdateMutation();
+  const deleteMutation = useManageableRoleDeleteMutation();
+
+  const rows = manageableRoles?.assignments || [];
+  const labsByProgram = useMemo(() => {
+    const programs = manageableRoles?.programs || [];
+    return new Map(programs.map((program) => [program.id, new Set(program.labs)]));
+  }, [manageableRoles?.programs]);
+
+  if (!manageableRoles || manageableRoles.programs.length === 0) {
+    return null;
+  }
+
+  const selectedProgramLabs = manageableRoles.labs.filter((lab) =>
+    form.program ? labsByProgram.get(form.program)?.has(lab.id) : true
+  );
+  const roleOptions = manageableRoles.roles.filter((role) =>
+    form.location === 'program'
+      ? role.name === TARole.ProgramLead
+      : role.name === TARole.Expert || role.name === TARole.LabLead
+  );
+
+  const handleAdd = () => {
+    const firstProgram = manageableRoles.programs[0]?.id;
+    const firstLab = manageableRoles.labs.find((lab) =>
+      firstProgram ? labsByProgram.get(firstProgram)?.has(lab.id) : true
+    )?.id;
+    setForm({
+      ...emptyForm,
+      user: manageableRoles.users[0]?.id || 0,
+      role: manageableRoles.roles.find((role) => role.name === TARole.Expert)?.id || 0,
+      program: firstProgram,
+      lab: firstLab,
+    });
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (assignment: TAManageableRoleAssignment) => {
+    setForm(toForm(assignment));
+    setDialogOpen(true);
+  };
+
+  const handleSubmit = async () => {
+    if (form.assignment_id) {
+      await updateMutation.mutateAsync(form);
+    } else {
+      await createMutation.mutateAsync(form);
+    }
+    setDialogOpen(false);
+  };
+
+  const columns: GridColDef<TAManageableRoleAssignment>[] = [
+    {
+      field: 'user',
+      headerName: 'User',
+      flex: 1,
+      minWidth: 220,
+      valueGetter: (_, row) => row.user.name || row.user.email,
+    },
+    {
+      field: 'role',
+      headerName: 'Role',
+      width: 140,
+      valueGetter: (_, row) => row.role.name,
+    },
+    {
+      field: 'location',
+      headerName: 'Level',
+      width: 120,
+      valueGetter: (_, row) => (row.location === 'program' ? 'Program' : 'Lab'),
+    },
+    {
+      field: 'program',
+      headerName: 'Program',
+      flex: 1,
+      minWidth: 200,
+      valueGetter: (_, row) => row.program?.name || row.instance?.name || '',
+    },
+    {
+      field: 'instance',
+      headerName: 'Lab',
+      flex: 1,
+      minWidth: 180,
+      valueGetter: (_, row) => (row.location === 'lab' ? row.instance?.name : ''),
+    },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      sortable: false,
+      filterable: false,
+      width: 104,
+      renderCell: ({ row }) => (
+        <Stack direction="row" spacing={0.5}>
+          <Tooltip title="Edit role">
+            <IconButton size="small" onClick={() => handleEdit(row)}>
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Revoke role">
+            <IconButton
+              size="small"
+              onClick={() =>
+                deleteMutation.mutate({
+                  assignment_id: row.assignment_id,
+                  location: row.location as 'program' | 'lab',
+                })
+              }
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      ),
+    },
+  ];
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <Box sx={{ flexGrow: 1 }}>
+          <Typography variant="h4" component="h2" fontWeight="bold">
+            Roles Manager
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleAdd}>
+          Add role
+        </Button>
+      </Stack>
+      <Paper elevation={1} sx={{ borderWidth: 1, borderColor: 'divider', borderStyle: 'solid' }}>
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          getRowId={(row) => `${row.location}-${row.assignment_id}`}
+          disableRowSelectionOnClick
+          pageSizeOptions={[10, 25, 50]}
+          initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+          sx={{ backgroundColor: 'white' }}
+        />
+      </Paper>
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>{form.assignment_id ? 'Edit role' : 'Add role'}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ paddingTop: 1 }}>
+            <FormControl fullWidth>
+              <InputLabel>User</InputLabel>
+              <Select
+                label="User"
+                value={form.user}
+                onChange={(event) => setForm({ ...form, user: Number(event.target.value) })}
+              >
+                {manageableRoles.users.map((user) => (
+                  <MenuItem key={user.id} value={user.id}>
+                    {user.name || user.email}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel>Level</InputLabel>
+              <Select
+                label="Level"
+                value={form.location}
+                onChange={(event) =>
+                  setForm({
+                    ...form,
+                    location: event.target.value as 'program' | 'lab',
+                    role:
+                      event.target.value === 'program'
+                        ? manageableRoles.roles.find((role) => role.name === TARole.ProgramLead)
+                            ?.id || 0
+                        : manageableRoles.roles.find((role) => role.name === TARole.Expert)?.id ||
+                          0,
+                  })
+                }
+              >
+                {manageableRoles.is_admin && <MenuItem value="program">Program</MenuItem>}
+                <MenuItem value="lab">Lab</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel>Role</InputLabel>
+              <Select
+                label="Role"
+                value={form.role}
+                onChange={(event) => setForm({ ...form, role: Number(event.target.value) })}
+              >
+                {roleOptions.map((role) => (
+                  <MenuItem key={role.id} value={role.id}>
+                    {role.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel>Program</InputLabel>
+              <Select
+                label="Program"
+                value={form.program || ''}
+                onChange={(event) => {
+                  const program = Number(event.target.value);
+                  const lab = manageableRoles.labs.find((item) =>
+                    labsByProgram.get(program)?.has(item.id)
+                  )?.id;
+                  setForm({ ...form, program, lab });
+                }}
+              >
+                {manageableRoles.programs.map((program) => (
+                  <MenuItem key={program.id} value={program.id}>
+                    {program.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            {form.location === 'lab' && (
+              <FormControl fullWidth>
+                <InputLabel>Lab</InputLabel>
+                <Select
+                  label="Lab"
+                  value={form.lab || ''}
+                  onChange={(event) => setForm({ ...form, lab: Number(event.target.value) })}
+                >
+                  {selectedProgramLabs.map((lab) => (
+                    <MenuItem key={lab.id} value={lab.id}>
+                      {lab.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={
+              createMutation.isPending ||
+              updateMutation.isPending ||
+              !form.user ||
+              !form.role ||
+              !form.program ||
+              (form.location === 'lab' && !form.lab)
+            }
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};

--- a/frontend/src/features/profile/RolesManager.tsx
+++ b/frontend/src/features/profile/RolesManager.tsx
@@ -118,16 +118,16 @@ export const RolesManager: React.FC = () => {
       valueGetter: (_, row) => row.user.name || row.user.email,
     },
     {
-      field: 'role',
-      headerName: 'Role',
-      width: 140,
-      valueGetter: (_, row) => row.role.name,
-    },
-    {
       field: 'location',
       headerName: 'Level',
       width: 120,
       valueGetter: (_, row) => (row.location === 'program' ? 'Program' : 'Lab'),
+    },
+    {
+      field: 'role',
+      headerName: 'Role',
+      width: 140,
+      valueGetter: (_, row) => row.role.name,
     },
     {
       field: 'program',

--- a/frontend/src/features/profile/RolesManager.tsx
+++ b/frontend/src/features/profile/RolesManager.tsx
@@ -1,7 +1,6 @@
 import {
   manageableRolesQueryOptions,
   useManageableRoleCreateMutation,
-  useManageableRoleDeleteMutation,
   useManageableRoleUpdateMutation,
 } from '@/api/queryOptions';
 import {
@@ -33,6 +32,7 @@ import {
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
+import { RoleDeleteDialog } from './RoleDeleteDialog';
 
 const emptyForm: TAManageableRoleMutation = {
   location: 'lab',
@@ -55,11 +55,14 @@ export const RolesManager: React.FC = () => {
   const { data } = useSuspenseQuery(manageableRolesQueryOptions());
   const manageableRoles = data as TAManageableRolesResponse | null;
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [roleDeleteDialogOpen, setRoleDeleteDialogOpen] = useState(false);
+  const [selectedAssignment, setSelectedAssignment] = useState<TAManageableRoleAssignment | null>(
+    null
+  );
   const [form, setForm] = useState<TAManageableRoleMutation>(emptyForm);
 
   const createMutation = useManageableRoleCreateMutation();
   const updateMutation = useManageableRoleUpdateMutation();
-  const deleteMutation = useManageableRoleDeleteMutation();
 
   const rows = manageableRoles?.assignments || [];
   const labsByProgram = useMemo(() => {
@@ -109,6 +112,15 @@ export const RolesManager: React.FC = () => {
     setDialogOpen(false);
   };
 
+  const handleOpenRoleDeleteDialog = (assignment: TAManageableRoleAssignment) => {
+    setSelectedAssignment(assignment);
+    setRoleDeleteDialogOpen(true);
+  };
+
+  const handleCloseRoleDeleteDialog = () => {
+    setRoleDeleteDialogOpen(false);
+  };
+
   const columns: GridColDef<TAManageableRoleAssignment>[] = [
     {
       field: 'user',
@@ -150,22 +162,20 @@ export const RolesManager: React.FC = () => {
       filterable: false,
       width: 104,
       renderCell: ({ row }) => (
-        <Stack direction="row" spacing={0.5}>
+        <Stack
+          direction="row"
+          spacing={0.5}
+          alignItems="center"
+          justifyContent="center"
+          sx={{ height: '100%' }}
+        >
           <Tooltip title="Edit role">
             <IconButton size="small" onClick={() => handleEdit(row)}>
               <EditIcon fontSize="small" />
             </IconButton>
           </Tooltip>
           <Tooltip title="Revoke role">
-            <IconButton
-              size="small"
-              onClick={() =>
-                deleteMutation.mutate({
-                  assignment_id: row.assignment_id,
-                  location: row.location as 'program' | 'lab',
-                })
-              }
-            >
+            <IconButton size="small" onClick={() => handleOpenRoleDeleteDialog(row)}>
               <DeleteIcon fontSize="small" />
             </IconButton>
           </Tooltip>
@@ -307,6 +317,11 @@ export const RolesManager: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+      <RoleDeleteDialog
+        open={roleDeleteDialogOpen}
+        onClose={handleCloseRoleDeleteDialog}
+        roleAssignment={selectedAssignment}
+      />
     </Stack>
   );
 };

--- a/frontend/src/routes/_with-nav/_private/profile.tsx
+++ b/frontend/src/routes/_with-nav/_private/profile.tsx
@@ -1,5 +1,10 @@
-import { identitiesQueryOptions, topicsQueryOptions } from '@/api/queryOptions';
+import {
+  identitiesQueryOptions,
+  manageableRolesQueryOptions,
+  topicsQueryOptions,
+} from '@/api/queryOptions';
 import { RolesGrid } from '@/features/profile/RolesGrid';
+import { RolesManager } from '@/features/profile/RolesManager';
 import { UserInfoDialog } from '@/features/profile/UserInfoDialog';
 import { useUser } from '@/hooks/useUser';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
@@ -22,6 +27,7 @@ import { useEffect, useState } from 'react';
 export const Route = createFileRoute('/_with-nav/_private/profile')({
   loader: async ({ context }) => {
     await context.queryClient.ensureQueryData(topicsQueryOptions());
+    await context.queryClient.ensureQueryData(manageableRolesQueryOptions());
   },
   component: ProfilePage,
 });
@@ -104,6 +110,7 @@ function ProfilePage() {
           </Alert>
         )}
         <RolesGrid identities={identities || []} />
+        <RolesManager />
       </Stack>
     </Container>
   );

--- a/frontend/src/routes/_with-nav/_private/profile.tsx
+++ b/frontend/src/routes/_with-nav/_private/profile.tsx
@@ -13,7 +13,6 @@ import {
   Alert,
   AlertTitle,
   Box,
-  Button,
   Container,
   IconButton,
   Link,
@@ -84,17 +83,7 @@ function ProfilePage() {
           </Stack>
         </Box>
       </Stack>
-      <Stack spacing={2}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Typography variant="h4" component="h2" fontWeight="bold" sx={{ flexGrow: 1 }}>
-            My Roles
-          </Typography>
-          <Box>
-            <Link href="https://forms.gle/etALWnsaZd7ZyFCeA" target="_blank">
-              <Button variant="contained">Request a new role</Button>
-            </Link>
-          </Box>
-        </Stack>
+      <Stack spacing={4}>
         {(!identities || identities.length === 0) && (
           <Alert severity="warning">
             <AlertTitle>You don't have any roles assigned yet.</AlertTitle>


### PR DESCRIPTION
Resolves #130 

Adds a new `/mangeable-roles` endpoint for adding, editing, and revoking roles. This powers a Roles Manager table on the profile page which shows all the roles that a user is allowed to manage based on their own current roles.

<img width="1267" height="445" alt="Screenshot 2026-07-14 at 12 47 25 PM" src="https://github.com/user-attachments/assets/c669577d-ee02-479b-a43a-b69d0982f9c8" />
