### PR TITLE
Add standalone cancel request button

### DIFF
--- a/backend/api/core/views/request.py
+++ b/backend/api/core/views/request.py
@@ -222,7 +222,7 @@ class RequestDetailView(BaseUserAwareRequest):
         # Compute which actions this user is permitted to perform on this request.
         # The frontend uses this list to show/hide UI controls, avoiding duplicated logic.
 
-        # Status-agnostic permissions
+        # All status-agnostic permissions
         permission_map = [
             ('edit-depth', CanEditDepth),
             ('edit-effort', CanEditEffort),
@@ -239,7 +239,6 @@ class RequestDetailView(BaseUserAwareRequest):
             ('transfer-organization-type', CanTransferOrganizationType),
             ('edit-closeout-responses', CanEditCloseoutResponses),
             ('assign-forward-to-reception', CanAssignForwardToReception),
-            ('cancel-request', CanCancel),
             ('reopen-request', CanReopen),
             ('add-note', CanAddNote),
             ('delete-note', CanDeleteNote),
@@ -247,7 +246,7 @@ class RequestDetailView(BaseUserAwareRequest):
             ('delete-attachment', CanDeleteAttachment),
         ]
 
-        # Status-dependent permissions
+        # All status-dependent permissions
         if ta_request.status.name in [REQUEST_STATUS.SCOPING]:
             permission_map.append(('assign-forward-to-program', CanAssignForwardToProgram))
         if ta_request.status.name in [REQUEST_STATUS.ASSIGNED_TO_PROGRAM, REQUEST_STATUS.REJECTED_BY_LAB]:
@@ -269,9 +268,12 @@ class RequestDetailView(BaseUserAwareRequest):
         if ta_request.status.name == REQUEST_STATUS.CLOSEOUT_REVIEW_BY_PROGRAM:
             permission_map.append(('approve-closeout-by-program', CanApproveCloseoutByProgram))
             permission_map.append(('reject-closeout-by-program', CanRejectCloseoutByProgram))
+        if ta_request.status.name not in [REQUEST_STATUS.COMPLETED, REQUEST_STATUS.UNABLE_TO_ADDRESS]:
+            permission_map.append(('cancel-request', CanCancel))
         if ta_request.status.name in [REQUEST_STATUS.COMPLETED, REQUEST_STATUS.UNABLE_TO_ADDRESS]:
             permission_map.append(('reopen-request', CanReopen))
 
+        # Compute which of the above actions the user is permitted to perform on this request.
         response_data["permissions"] = [
             action for action, perm_cls in permission_map
             if perm_cls().has_object_permission(request, self, ta_request)

--- a/frontend/src/features/requests/RequestCancelButton.tsx
+++ b/frontend/src/features/requests/RequestCancelButton.tsx
@@ -1,0 +1,87 @@
+import { TARequestDetail } from '@/api/dashboard/types';
+import { useCancelMutation } from '@/api/queryOptions';
+import { queryClient } from '@/App';
+import { useAdminModeContext } from '@/features/admin-mode/AdminModeContext';
+import { useRequestsContext } from '@/features/requests/RequestsContext';
+import { useToastContext } from '@/features/toasts/ToastContext';
+import { ToastMessage } from '@/features/toasts/ToastMessage';
+import CancelIcon from '@mui/icons-material/Cancel';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import { Button, CircularProgress, Stack } from '@mui/material';
+import { useNavigate } from '@tanstack/react-router';
+
+interface RequestCancelButtonProps {
+  request: TARequestDetail;
+}
+
+/**
+ * Button for canceling a request.
+ * This component contains the logic to determine whether the current user
+ * should see this button and be able to cancel the request.
+ */
+export const RequestCancelButton: React.FC<RequestCancelButtonProps> = ({ request }) => {
+  const navigate = useNavigate();
+  const { isAdminMode } = useAdminModeContext();
+  const { tab, nextId, previousId } = useRequestsContext();
+  const { setShowToast, setToastMessage } = useToastContext();
+  const onMutate = (message: string) => {
+    return () => {
+      setShowToast(true);
+      setToastMessage(
+        <ToastMessage>
+          <Stack direction="row" alignItems="center">
+            <CircularProgress size="1.25rem" color="info" />
+            <span>{message}</span>
+          </Stack>
+        </ToastMessage>
+      );
+    };
+  };
+  const onSuccess = (message: string) => {
+    return () => {
+      queryClient.invalidateQueries();
+      setShowToast(true);
+      setToastMessage(<ToastMessage icon={<CheckCircleIcon />}>{message}</ToastMessage>);
+      if (nextId) {
+        navigate({
+          to: `/requests/${tab}/${nextId}`,
+          params: { requestId: nextId.toString() },
+        });
+      } else if (previousId) {
+        navigate({
+          to: `/requests/${tab}/${previousId}`,
+          params: { requestId: previousId.toString() },
+        });
+      }
+    };
+  };
+  const onError = (error: Error) => {
+    setShowToast(true);
+    setToastMessage(<ToastMessage icon={<ErrorIcon />}>{error.message}</ToastMessage>);
+  };
+  const cancelRequestMutation = useCancelMutation(request.id.toString(), isAdminMode, {
+    onMutate: onMutate('Canceling request'),
+    onSuccess: onSuccess('Request canceled'),
+    onError: onError,
+  });
+
+  const handleCancel = () => {
+    cancelRequestMutation.mutate();
+  };
+
+  if (!request.permissions.includes('cancel-request')) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="contained"
+      color="error"
+      startIcon={<CancelIcon />}
+      onClick={() => handleCancel()}
+    >
+      Cancel request
+    </Button>
+  );
+};

--- a/frontend/src/features/requests/RequestHeader.tsx
+++ b/frontend/src/features/requests/RequestHeader.tsx
@@ -12,6 +12,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRequestsContext } from './RequestsContext';
 import { RequestDatesDialog } from '@/features/requests/RequestDatesDialog';
 import { RequestCloseoutForm } from '@/features/requests/RequestCloseoutForm';
+import { RequestCancelButton } from '@/features/requests/RequestCancelButton';
 
 interface RequestHeaderProps {
   request: TARequestDetail;
@@ -82,6 +83,7 @@ export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
         </Stack>
       </Stack>
       <Stack direction="row">
+        <RequestCancelButton request={request} />
         <RequestAssignBackwardButton request={request} />
         <RequestAssignForwardButton request={request} />
       </Stack>


### PR DESCRIPTION
Resolves #179 

There is now a standalone cancel button for requests. This is visible if the user has the `'cancel-request'` permission on the given request. Admins and Program Leads are allowed to cancel active requests.

Confirmation, "Are you sure...?" modals are coming in a separate PR.