### PR TITLE
Add and improve confirmation dialogs

### DIFF
--- a/backend/api/core/views/owner.py
+++ b/backend/api/core/views/owner.py
@@ -33,17 +33,24 @@ class OwnerListView(BaseUserAwareRequest):
             return owners_set.filter(domain_type=DOMAINTYPE.PROGRAM)
         
         if ta_request.status.name in [REQUEST_STATUS.ASSIGNED_TO_PROGRAM, REQUEST_STATUS.REJECTED_BY_LAB] and IsProgramLead().has_object_permission(self.request, self, ta_request):
+            # Backwards
+            reception_owners = owners_set.filter(domain_type=DOMAINTYPE.RECEPTION)
+            allowed_owners = allowed_owners | reception_owners
+            # Forwards
             for lab in ta_request.program.labs.all():
                 allowed_owners = allowed_owners | Owner.objects.filter(pk=lab.owner.pk)
 
         if ta_request.status.name in [REQUEST_STATUS.ASSIGNED_TO_LAB, REQUEST_STATUS.REJECTED_BY_EXPERT] and IsLabLead().has_object_permission(self.request, self, ta_request):
+            # Backwards
+            program_owners = owners_set.filter(domain_type=DOMAINTYPE.PROGRAM, program=ta_request.program)
+            # Forwards
             experts_in_lab = LabRoleAssignment.objects.filter(
                 role=Role.objects.get(name=ROLE.EXPERT),
                 instance=ta_request.lab,
                 program=ta_request.program,
             ).values_list('user', flat=True)
             expert_owners = owners_set.filter(domain_type=DOMAINTYPE.EXPERT, expert__in=experts_in_lab)
-            allowed_owners = allowed_owners | expert_owners
+            allowed_owners = allowed_owners | program_owners | expert_owners
 
         return allowed_owners.distinct()
         # if ta_request.status.name in [REQUEST_STATUS.ASSIGNED_TO_LAB, REQUEST_STATUS.REJECTED_BY_EXPERT]:

--- a/backend/api/core/views/request.py
+++ b/backend/api/core/views/request.py
@@ -584,6 +584,7 @@ class RequestApproveCloseoutFormByProgramView(BaseUserAwareRequest):
                 closeout_form.save()
 
                 ta_request.status = get_status(REQUEST_STATUS.COMPLETED)
+                ta_request.actual_completion_date = timezone.now()
                 ta_request.owner = None
                 ta_request.save()
 
@@ -611,6 +612,7 @@ class RequestReopenView(BaseUserAwareRequest):
 
         try:
             ta_request.status = RequestStatus.objects.get(name=REQUEST_STATUS.SCOPING)
+            ta_request.actual_completion_date = None
             ta_request.owner = Owner.objects.get(pk=Owner.get_default_pk())
             ta_request.program = None
             ta_request.lab = None

--- a/backend/api/core/views/request.py
+++ b/backend/api/core/views/request.py
@@ -239,7 +239,6 @@ class RequestDetailView(BaseUserAwareRequest):
             ('transfer-organization-type', CanTransferOrganizationType),
             ('edit-closeout-responses', CanEditCloseoutResponses),
             ('assign-forward-to-reception', CanAssignForwardToReception),
-            ('reopen-request', CanReopen),
             ('add-note', CanAddNote),
             ('delete-note', CanDeleteNote),
             ('add-attachment', CanAddAttachment),

--- a/frontend/src/api/queryOptions.tsx
+++ b/frontend/src/api/queryOptions.tsx
@@ -94,7 +94,7 @@ export const statusesQueryOptions = (isAdminMode?: boolean) =>
 export const ownersQueryOptions = (requestId: string, isAdminMode?: boolean) =>
   queryOptions({
     staleTime: 120_000, // stale after 2 minutes
-    queryKey: ['owners', isAdminMode],
+    queryKey: ['owners', requestId, isAdminMode],
     queryFn: () => fetchData<TAOwner[]>(`${apiUrl}/requests/${requestId}/owners/`, isAdminMode),
   });
 

--- a/frontend/src/components/Blockquote.tsx
+++ b/frontend/src/components/Blockquote.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material';
+import { PropsWithChildren } from 'react';
+
+interface BlockquoteProps extends PropsWithChildren {
+  /** Only show one line of text and cut off the rest with an ellipsis */
+  clamp?: boolean;
+}
+
+export const Blockquote: React.FC<BlockquoteProps> = ({ clamp, children }) => {
+  return (
+    <Box
+      component="blockquote"
+      sx={{
+        borderLeft: '4px solid',
+        borderColor: 'divider',
+        pl: 2,
+        ml: 0,
+        my: 1,
+        whiteSpace: clamp ? 'nowrap' : 'normal',
+        overflow: clamp ? 'hidden' : 'visible',
+        textOverflow: clamp ? 'ellipsis' : 'clip',
+      }}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/frontend/src/features/requests/RequestAssignBackwardButton.tsx
+++ b/frontend/src/features/requests/RequestAssignBackwardButton.tsx
@@ -129,7 +129,8 @@ export const RequestAssignBackwardButton: React.FC<RequestAssignBackwardButtonPr
 
   if (
     !currentStep.backwardPermission ||
-    !request.permissions.includes(currentStep.backwardPermission)
+    !request.permissions.includes(currentStep.backwardPermission) ||
+    currentStep.backwardPermission === 'cancel-request'
   ) {
     return null;
   }

--- a/frontend/src/features/requests/RequestAttachments.tsx
+++ b/frontend/src/features/requests/RequestAttachments.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
+  DialogContentText,
   DialogTitle,
   IconButton,
   Stack,
@@ -35,7 +36,7 @@ export const RequestAttachments: React.FC<RequestAttachmentsProps> = ({
   const { isAdminMode } = useAdminModeContext();
   const [showUploadDialog, setShowUploadDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [attachmentToDelete, setAttachmentToDelete] = useState<number>();
+  const [attachmentToDelete, setAttachmentToDelete] = useState<TAAttachment>();
   const uploadAttachmentMutation = useAttachmentMutation(requestId.toString(), isAdminMode);
   const deleteAttachmentMutation = useDeleteAttachmentMutation(requestId.toString(), isAdminMode);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -93,14 +94,14 @@ export const RequestAttachments: React.FC<RequestAttachmentsProps> = ({
       .then((blob) => downloadBlob(blob, `${attachmentTitle}`));
   };
 
-  const handleInitiateDelete = (attachmentId: number) => {
-    setAttachmentToDelete(attachmentId);
+  const handleInitiateDelete = (attachment: TAAttachment) => {
+    setAttachmentToDelete(attachment);
     setShowDeleteDialog(true);
   };
 
   const handleDelete = () => {
     if (attachmentToDelete) {
-      deleteAttachmentMutation.mutate(attachmentToDelete.toString());
+      deleteAttachmentMutation.mutate(attachmentToDelete.id.toString());
       setShowDeleteDialog(false);
     }
   };
@@ -155,7 +156,7 @@ export const RequestAttachments: React.FC<RequestAttachmentsProps> = ({
               </Typography>
             </Stack>
             {permissions.includes('delete-attachment') && (
-              <IconButton onClick={() => handleInitiateDelete(attachment.id)}>
+              <IconButton onClick={() => handleInitiateDelete(attachment)}>
                 <DeleteIcon />
               </IconButton>
             )}
@@ -217,8 +218,12 @@ export const RequestAttachments: React.FC<RequestAttachmentsProps> = ({
       <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
         {!deleteAttachmentMutation.isPending && (
           <>
+            <DialogTitle>Delete Attachment</DialogTitle>
             <DialogContent>
-              <Typography>Are you sure you want to delete this attachment?</Typography>
+              <DialogContentText>
+                Are you sure you want to delete the attachment,{' '}
+                <strong>{attachmentToDelete?.title}</strong>?
+              </DialogContentText>
             </DialogContent>
             <DialogActions>
               <Button variant="outlined" onClick={() => setShowDeleteDialog(false)}>

--- a/frontend/src/features/requests/RequestCancelButton.tsx
+++ b/frontend/src/features/requests/RequestCancelButton.tsx
@@ -9,7 +9,13 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import { Button, CircularProgress, Stack } from '@mui/material';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
 import { useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
 interface RequestCancelButtonProps {
   request: TARequestDetail;
@@ -25,6 +31,7 @@ export const RequestCancelButton: React.FC<RequestCancelButtonProps> = ({ reques
   const { isAdminMode } = useAdminModeContext();
   const { tab, nextId, previousId } = useRequestsContext();
   const { setShowToast, setToastMessage } = useToastContext();
+  const [dialogOpen, setDialogOpen] = useState(false);
   const onMutate = (message: string) => {
     return () => {
       setShowToast(true);
@@ -75,13 +82,49 @@ export const RequestCancelButton: React.FC<RequestCancelButtonProps> = ({ reques
   }
 
   return (
-    <Button
-      variant="contained"
-      color="error"
-      startIcon={<CancelIcon />}
-      onClick={() => handleCancel()}
-    >
-      Cancel request
-    </Button>
+    <>
+      <Button
+        variant="contained"
+        color="error"
+        startIcon={<CancelIcon />}
+        onClick={() => setDialogOpen(true)}
+      >
+        Cancel request
+      </Button>
+      <Dialog
+        open={dialogOpen}
+        maxWidth="sm"
+        fullWidth
+        onClose={() => setDialogOpen(false)}
+        disableRestoreFocus
+      >
+        <DialogTitle>Cancel Request</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to cancel request <strong>#{request.id}</strong> from{' '}
+            <strong>{request.organization?.name}</strong>?
+          </DialogContentText>
+          <DialogContentText sx={{ mt: 2 }}>
+            Only admins and coordinators can reopen requests after they have been canceled.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: 'space-between' }}>
+          <span></span>
+          <Stack direction="row">
+            <Button onClick={() => setDialogOpen(false)}>Keep request</Button>
+            <Button
+              variant="contained"
+              color="error"
+              onClick={() => {
+                handleCancel();
+                setDialogOpen(false);
+              }}
+            >
+              Cancel request
+            </Button>
+          </Stack>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 };

--- a/frontend/src/features/requests/RequestCancelButton.tsx
+++ b/frontend/src/features/requests/RequestCancelButton.tsx
@@ -100,13 +100,15 @@ export const RequestCancelButton: React.FC<RequestCancelButtonProps> = ({ reques
       >
         <DialogTitle>Cancel Request</DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            Are you sure you want to cancel request <strong>#{request.id}</strong> from{' '}
-            <strong>{request.organization?.name}</strong>?
-          </DialogContentText>
-          <DialogContentText sx={{ mt: 2 }}>
-            Only admins and coordinators can reopen requests after they have been canceled.
-          </DialogContentText>
+          <Stack>
+            <DialogContentText>
+              Are you sure you want to cancel request <strong>#{request.id}</strong> from{' '}
+              <strong>{request.organization?.name}</strong>?
+            </DialogContentText>
+            <DialogContentText>
+              Only admins and coordinators can reopen requests after they have been canceled.
+            </DialogContentText>
+          </Stack>
         </DialogContent>
         <DialogActions sx={{ justifyContent: 'space-between' }}>
           <span></span>

--- a/frontend/src/features/requests/RequestCloseoutForm.tsx
+++ b/frontend/src/features/requests/RequestCloseoutForm.tsx
@@ -222,7 +222,11 @@ export const RequestCloseoutForm: React.FC<RequestCloseoutFormProps> = ({
     } else if (!closeoutForm.approved_by_program) {
       return 'Approve and mark completed';
     }
-  }, [closeoutForm?.submitted_date, closeoutForm?.approved_by_program]);
+  }, [
+    closeoutForm?.submitted_date,
+    closeoutForm?.approved_by_lab,
+    closeoutForm?.approved_by_program,
+  ]);
 
   const labRejectButtonText = useMemo(() => {
     if (!closeoutForm?.submitted_date || closeoutForm.approved_by_lab) {

--- a/frontend/src/features/requests/RequestHeader.tsx
+++ b/frontend/src/features/requests/RequestHeader.tsx
@@ -7,6 +7,7 @@ import { RequestAssignForwardButton } from '@/features/requests/RequestAssignFor
 import { expertsQueryOptions } from '@/api/queryOptions';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CircleIcon from '@mui/icons-material/Circle';
 import { Box, Drawer, IconButton, Stack, Typography } from '@mui/material';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRequestsContext } from './RequestsContext';
@@ -40,45 +41,50 @@ export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
             fontWeight: 'bold',
           }}
         >
-          {request.customers[0]?.name || 'Missing customer contact'} (
-          {request.organization?.state.abbreviation})
+          {request.customers[0]?.name || 'Missing customer contact'} (#{request.id})
         </Typography>
-        <Stack direction="row" alignItems="center">
-          {previousId !== null && (
-            <AppLink
-              to={`/requests/${tab}/$requestId`}
-              params={{
-                requestId: previousId.toString(),
-              }}
-            >
-              <IconButton size="small">
-                <ChevronLeftIcon />
-              </IconButton>
-            </AppLink>
-          )}
-          {previousId === null && (
-            <span>
-              <IconButton size="small" disabled>
-                <ChevronLeftIcon />
-              </IconButton>
-            </span>
-          )}
-          {nextId !== null && (
-            <AppLink to={`/requests/${tab}/$requestId`} params={{ requestId: nextId.toString() }}>
-              <IconButton size="small">
-                <ChevronRightIcon />
-              </IconButton>
-            </AppLink>
-          )}
-          {nextId === null && (
-            <span>
-              <IconButton size="small" disabled>
-                <ChevronRightIcon />
-              </IconButton>
-            </span>
-          )}
-          <Typography variant="h6" component="h2" color="grey.600">
-            Request #{request.id}
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Stack direction="row" alignItems="center">
+            {previousId !== null && (
+              <AppLink
+                to={`/requests/${tab}/$requestId`}
+                params={{
+                  requestId: previousId.toString(),
+                }}
+              >
+                <IconButton size="small">
+                  <ChevronLeftIcon />
+                </IconButton>
+              </AppLink>
+            )}
+            {previousId === null && (
+              <span>
+                <IconButton size="small" disabled>
+                  <ChevronLeftIcon />
+                </IconButton>
+              </span>
+            )}
+            {nextId !== null && (
+              <AppLink to={`/requests/${tab}/$requestId`} params={{ requestId: nextId.toString() }}>
+                <IconButton size="small">
+                  <ChevronRightIcon />
+                </IconButton>
+              </AppLink>
+            )}
+            {nextId === null && (
+              <span>
+                <IconButton size="small" disabled>
+                  <ChevronRightIcon />
+                </IconButton>
+              </span>
+            )}
+          </Stack>
+          <Typography variant="subtitle1" color="grey.600">
+            {request.organization?.state.name || 'Missing state'}
+          </Typography>
+          <CircleIcon sx={{ fontSize: 8, color: 'grey.600' }} />
+          <Typography variant="subtitle1" color="grey.600">
+            {request.organization?.name || 'Missing organization'}
           </Typography>
         </Stack>
       </Stack>

--- a/frontend/src/features/requests/RequestHeader.tsx
+++ b/frontend/src/features/requests/RequestHeader.tsx
@@ -82,7 +82,7 @@ export const RequestHeader: React.FC<RequestHeaderProps> = ({ request }) => {
           <Typography variant="subtitle1" color="grey.600">
             {request.organization?.state.name || 'Missing state'}
           </Typography>
-          <CircleIcon sx={{ fontSize: 8, color: 'grey.600' }} />
+          <CircleIcon sx={{ fontSize: 6, color: 'grey.600' }} />
           <Typography variant="subtitle1" color="grey.600">
             {request.organization?.name || 'Missing organization'}
           </Typography>

--- a/frontend/src/features/requests/RequestNotes.tsx
+++ b/frontend/src/features/requests/RequestNotes.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
+  DialogContentText,
   DialogTitle,
   IconButton,
   Stack,
@@ -18,6 +19,7 @@ import { useAdminModeContext } from '@/features/admin-mode/AdminModeContext';
 import { formatDatetime } from '../../utils/utils';
 import { useEffect, useState } from 'react';
 import { useUser } from '@/hooks/useUser';
+import { Blockquote } from '@/components/Blockquote';
 
 interface RequestNotesProps {
   requestId: TARequestDetail['id'];
@@ -30,7 +32,7 @@ export const RequestNotes: React.FC<RequestNotesProps> = ({ requestId, permissio
   const user = useUser();
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [noteToDelete, setNoteToDelete] = useState<number>();
+  const [noteToDelete, setNoteToDelete] = useState<TANote>();
   const createNoteMutation = useCreateNoteMutation(requestId.toString(), isAdminMode);
   const deleteNoteMutation = useDeleteNoteMutation(requestId.toString(), isAdminMode);
   const [noteDescription, setNoteDescription] = useState('');
@@ -55,14 +57,14 @@ export const RequestNotes: React.FC<RequestNotesProps> = ({ requestId, permissio
     });
   };
 
-  const handleInitiateDelete = (noteId: number) => {
-    setNoteToDelete(noteId);
+  const handleInitiateDelete = (note: TANote) => {
+    setNoteToDelete(note);
     setShowDeleteDialog(true);
   };
 
   const handleDelete = () => {
     if (noteToDelete) {
-      deleteNoteMutation.mutate(noteToDelete.toString());
+      deleteNoteMutation.mutate(noteToDelete.id.toString());
       setShowDeleteDialog(false);
     }
   };
@@ -106,7 +108,7 @@ export const RequestNotes: React.FC<RequestNotesProps> = ({ requestId, permissio
                 {formatDatetime(note.timestamp)}
               </Typography>
               {permissions.includes('delete-note') && (
-                <IconButton onClick={() => handleInitiateDelete(note.id)} size="small">
+                <IconButton onClick={() => handleInitiateDelete(note)} size="small">
                   <DeleteIcon fontSize="small" />
                 </IconButton>
               )}
@@ -155,8 +157,14 @@ export const RequestNotes: React.FC<RequestNotesProps> = ({ requestId, permissio
       <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
         {!deleteNoteMutation.isPending && (
           <>
+            <DialogTitle>Delete Note</DialogTitle>
             <DialogContent>
-              <Typography>Are you sure you want to delete this note?</Typography>
+              <Stack>
+                <DialogContentText>Are you sure you want to delete this note?</DialogContentText>
+                <DialogContentText>
+                  <Blockquote clamp>{noteToDelete?.content}</Blockquote>
+                </DialogContentText>
+              </Stack>
             </DialogContent>
             <DialogActions>
               <Button variant="outlined" onClick={() => setShowDeleteDialog(false)}>

--- a/frontend/src/features/requests/RequestsList.tsx
+++ b/frontend/src/features/requests/RequestsList.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { TARequest } from '../../api/dashboard/types';
 import { formatDatetime, sortAndFilterRequests, statusMap } from '../../utils/utils';
 import { useRequestsContext } from './RequestsContext';
+import CircleIcon from '@mui/icons-material/Circle';
 import HourglassBottomIcon from '@mui/icons-material/HourglassBottom';
 import TaskAltIcon from '@mui/icons-material/TaskAlt';
 
@@ -123,8 +124,9 @@ export const RequestsList: React.FC<RequestsListProps> = ({
                 <Typography component="h4" fontWeight="bold">
                   {request.customer_name || 'Missing customer contact'}
                 </Typography>
+                <CircleIcon sx={{ fontSize: 6 }} />
                 <Typography component="h4" fontWeight="bold">
-                  ({request.organization?.state.name})
+                  {request.organization?.state.name}
                 </Typography>
               </Stack>
               <Typography>#{request.id}</Typography>


### PR DESCRIPTION
Resolves #215 

This PR implements and improves confirmation dialogs where appropriate. We only show confirmation dialogs for destructive actions that either can't be undone or are difficult to undo. Non-destructive actions like moving a request forward/backward in the chain do not require confirmation.

Also fixes several bugs related to caching issues and handles auto setting the `actual_completion_date` for requests.